### PR TITLE
feat: add labels to kubernetes node (csp, region, zone)

### DIFF
--- a/src/core/model/vm.go
+++ b/src/core/model/vm.go
@@ -318,16 +318,16 @@ func (self *VM) AddNodeLabels(sshInfo *ssh.SSHInfo) error {
 	}
 
 	infos := map[string]interface{}{
-		"csp":    self.Csp,
-		"region": self.Region.Region,
+		"topology.cloud-barista.github.io/csp": self.Csp,
+		"topology.kubernetes.io/region":        self.Region.Region,
 	}
 	if self.Csp != config.CSP_AZURE {
-		infos["zone"] = self.Region.Zone
+		infos["topology.kubernetes.io/zone"] = self.Region.Zone
 	}
 
 	labels := ""
 	for key, value := range infos {
-		labels += fmt.Sprintf("%s/%s=%s ", config.NODE_LABELS_PREFIX, key, value)
+		labels += fmt.Sprintf("%s=%s ", key, value)
 	}
 
 	cmd = fmt.Sprintf("sudo kubectl label nodes %s %s --kubeconfig=/etc/kubernetes/%s;", hostName, labels, configFile)

--- a/src/core/service/cluster.go
+++ b/src/core/service/cluster.go
@@ -336,6 +336,20 @@ func CreateCluster(namespace string, req *model.ClusterReq) (*model.Cluster, err
 	}
 	logger.Infoln("end k8s join")
 
+	logger.Infoln("start add node labels")
+	for _, vm := range cpMcis.VMs {
+		sshInfo := ssh.SSHInfo{
+			UserName:   GetUserAccount(vm.Csp),
+			PrivateKey: []byte(vm.Credential),
+			ServerPort: fmt.Sprintf("%s:22", vm.PublicIP),
+		}
+		err := vm.AddNodeLabels(&sshInfo)
+		if err != nil {
+			logger.Warnf("failed to add node labels (vm=%s, cause=%s)", vm.Name, err)
+		}
+	}
+	logger.Infoln("end add node labels")
+
 	cluster.Complete()
 	cluster.Nodes = nodes
 

--- a/src/core/service/node.go
+++ b/src/core/service/node.go
@@ -190,6 +190,12 @@ func AddNode(namespace string, clusterName string, req *model.NodeReq) (*model.N
 			if err != nil {
 				c <- err
 			}
+
+			logger.Infof("add labels (vm=%s)", vm.Name)
+			err = vm.AddNodeLabels(&sshInfo)
+			if err != nil {
+				logger.Warnf("failed to add node labels (vm=%s, cause= %s)", vm.Name, err)
+			}
 		}(tvm.VM)
 	}
 

--- a/src/utils/config/const.go
+++ b/src/utils/config/const.go
@@ -41,6 +41,4 @@ const (
 	Terminated  VMStatus = "Terminated"
 	NotExist    VMStatus = "NotExist" // VM does not exist
 	Failed      VMStatus = "Failed"
-
-	NODE_LABELS_PREFIX = "topology.cloud-barista.github.io"
 )

--- a/src/utils/config/const.go
+++ b/src/utils/config/const.go
@@ -41,4 +41,6 @@ const (
 	Terminated  VMStatus = "Terminated"
 	NotExist    VMStatus = "NotExist" // VM does not exist
 	Failed      VMStatus = "Failed"
+
+	NODE_LABELS_PREFIX = "topology.cloud-barista.github.io"
 )


### PR DESCRIPTION
- feat: add labels to kubernetes node (csp, region, zone)
  - 프로비저닝 후 생성된 노드에 CSP, region, zone 레이블을 제공
  - e.g.
    - topology.cloud-barista.github.io/csp=gcp
    - topology.kubernetes.io/region=asia-northeast3
    - topology.kubernetes.io/zone=asia-northeast3-a
  - 참고 : https://kubernetes.io/ko/docs/reference/labels-annotations-taints/#topologykubernetesioregion