### PR TITLE
feat: add deleteMCIS/deleteVMs for createCluster/addNode failure

### DIFF
--- a/docs/test/conf.env
+++ b/docs/test/conf.env
@@ -1,4 +1,4 @@
-export MCKS_CALL_METHOD=GRPC
+export MCKS_CALL_METHOD=REST
 
 export c_URL_SPIDER="http://localhost:1024/spider"
 export c_URL_TUMBLEBUG="http://localhost:1323/tumblebug"

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/swaggo/echo-swagger v1.1.0
 	github.com/swaggo/swag v1.7.0
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/grpc v1.39.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -873,6 +873,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/src/core/model/tumblebug/mcis.go
+++ b/src/core/model/tumblebug/mcis.go
@@ -66,7 +66,7 @@ func (self *MCIS) DELETE() error {
 }
 
 func (self *MCIS) TERMINATE() error {
-	_, err := self.execute(http.MethodGet, fmt.Sprintf("/ns/%s/mcis/%s?action=terminate", self.namespace, self.Name), nil, model.Status{})
+	_, err := self.execute(http.MethodGet, fmt.Sprintf("/ns/%s/control/mcis/%s?action=terminate", self.namespace, self.Name), nil, model.Status{})
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (self *MCIS) TERMINATE() error {
 }
 
 func (self *MCIS) REFINE() error {
-	_, err := self.execute(http.MethodGet, fmt.Sprintf("/ns/%s/mcis/%s?action=refine", self.namespace, self.Name), nil, model.Status{})
+	_, err := self.execute(http.MethodGet, fmt.Sprintf("/ns/%s/control/mcis/%s?action=refine", self.namespace, self.Name), nil, model.Status{})
 	if err != nil {
 		return err
 	}

--- a/src/core/service/cluster.go
+++ b/src/core/service/cluster.go
@@ -143,13 +143,13 @@ func CreateCluster(namespace string, req *model.ClusterReq) (*model.Cluster, err
 			}
 
 			if nodeConfigInfo.Role == config.CONTROL_PLANE {
-				vm.Name = lang.GetNodeName(clusterName, config.CONTROL_PLANE, cIdx)
+				vm.Name = lang.GetNodeName(config.CONTROL_PLANE, cIdx)
 				if cIdx == 1 {
 					vmInfo.IsCPLeader = true
 					cluster.CpLeader = vm.Name
 				}
 			} else {
-				vm.Name = lang.GetNodeName(clusterName, config.WORKER, wIdx)
+				vm.Name = lang.GetNodeName(config.WORKER, wIdx)
 			}
 			vmInfo.Name = vm.Name
 

--- a/src/core/service/node.go
+++ b/src/core/service/node.go
@@ -127,9 +127,9 @@ func AddNode(namespace string, clusterName string, req *model.NodeReq) (*model.N
 			}
 
 			if nodeConfigInfo.Role == config.CONTROL_PLANE {
-				tvm.VM.Name = lang.GetNodeName(clusterName, config.CONTROL_PLANE, maxCIdx+cIdx)
+				tvm.VM.Name = lang.GetNodeName(config.CONTROL_PLANE, maxCIdx+cIdx)
 			} else {
-				tvm.VM.Name = lang.GetNodeName(clusterName, config.WORKER, maxWIdx+wIdx)
+				tvm.VM.Name = lang.GetNodeName(config.WORKER, maxWIdx+wIdx)
 			}
 
 			// vm 생성

--- a/src/utils/lang/functions.go
+++ b/src/utils/lang/functions.go
@@ -73,8 +73,8 @@ func GetRandomString(n int) string {
 }
 
 // get node name
-func GetNodeName(clusterName string, role string, idx int) string {
-	return fmt.Sprintf("%s-%s-%d-%s", clusterName, role[:1], idx, GetRandomString(5))
+func GetNodeName(role string, idx int) string {
+	return fmt.Sprintf("%s-%d-%s", role[:1], idx, GetRandomString(5))
 }
 
 func GetIdxToInt(idx string) int {


### PR DESCRIPTION
- feat: add deleteMCIS/deleteVMs for createCluster/addNode failure
  - 클러스터/노드 생성 실패 시 mcis/vm 삭제 로직 추가
- fix: change mcis control url
  - cb-tumblebug api 변경으로 mcis terminate/refine url 변경 (**CB-Tumblebug v0.4.8 이상에서 동작**)
- fix: remove cluster name from node name
  - node name 생성 규칙 변경
  - <cluster_name>-<c/w>-<idx>-<random_string> -> <c/w>-<idx>-<random_string>

### Tested with
  - CB-Spider (https://github.com/cloud-barista/cb-spider/releases/tag/v0.4.11)
  - CB-Tumblebug (https://github.com/cloud-barista/cb-tumblebug/releases/tag/v0.4.8)