### PR TITLE
feat: add mcis.systemLabel for monitoring

### DIFF
--- a/docs/test/README.md
+++ b/docs/test/README.md
@@ -29,6 +29,11 @@ $ docker run -d -p 1024:1024 --name cb-spider cloudbaristaorg/cb-spider:0.4.0
 $ docker run -d -p 1323:1323 --name cb-tumblebug --link cb-spider:cb-spider cloudbaristaorg/cb-tumblebug:0.4.0
 ```
 
+### CB-Dragonfly 실행 (모니터링 에이전트 설치를 원할 경우)
+
+- [CB-Dragonfly 실행 방법](https://github.com/cloud-barista/cb-dragonfly#2-실행-방법) 참조
+
+
 ### Cloud Connection Info. 등록
 
 #### `batch-register-cloud-info.sh` 활용

--- a/src/core/model/tumblebug/mcis.go
+++ b/src/core/model/tumblebug/mcis.go
@@ -13,6 +13,7 @@ type MCIS struct {
 	Model
 	Description string     `json:"description"`
 	Label       string     `json:"label"`
+	SystemLabel string     `json:"systemLabel"`
 	VMs         []model.VM `json:"vm"` // output
 }
 

--- a/src/core/service/cluster.go
+++ b/src/core/service/cluster.go
@@ -203,7 +203,8 @@ func CreateCluster(namespace string, req *model.ClusterReq) (*model.Cluster, err
 	}
 
 	// MCIS 생성
-	mcis.Label = "mcks"
+	mcis.Label = config.MCIS_LABEL
+	mcis.SystemLabel = config.MCIS_SYSTEMLABEL
 	logger.Infof("start create MCIS (namespace=%s, cluster=%s, mcis=%s)", namespace, clusterName, mcisName)
 	if err = mcis.POST(); err != nil {
 		cluster.FailReason(model.CreateMCISFailedReason, fmt.Sprintf("Failed to create MCIS. (cause=%v)", err))

--- a/src/utils/config/const.go
+++ b/src/utils/config/const.go
@@ -47,4 +47,7 @@ const (
 	LABEL_KEY_CSP    = "topology.cloud-barista.github.io/csp"
 	LABEL_KEY_REGION = "topology.kubernetes.io/region"
 	LABEL_KEY_ZONE   = "topology.kubernetes.io/zone"
+
+	MCIS_LABEL       = "mcks"
+	MCIS_SYSTEMLABEL = "Managed by MCKS"
 )


### PR DESCRIPTION
- feat: add mcis.systemLabel for monitoring
  - mcis 생성 시 systemLabel 값 추가
  - CB-Dragonfly 실행 방법 링크 추가 (for monitoring)

### Tested with
  - CB-Spider (https://github.com/cloud-barista/cb-spider/releases/tag/v0.4.18)
  - CB-Tumblebug (https://github.com/cloud-barista/cb-tumblebug/releases/tag/v0.4.15)
