### PR TITLE
fix: Duplicated private-ip problem on multiple VPCs

### DIFF
--- a/src/core/model/types.go
+++ b/src/core/model/types.go
@@ -4,12 +4,6 @@ import (
 	"github.com/cloud-barista/cb-mcks/src/core/app"
 )
 
-const (
-	LABEL_KEY_CSP    = "topology.cloud-barista.github.io/csp"
-	LABEL_KEY_REGION = "topology.kubernetes.io/region"
-	LABEL_KEY_ZONE   = "topology.kubernetes.io/zone"
-)
-
 type ClusterPhase string
 type ClusterReason string
 

--- a/src/core/provision/machine.go
+++ b/src/core/provision/machine.go
@@ -135,7 +135,7 @@ func (self *Machine) bootstrap(networkCni app.NetworkCni) error {
 	}
 
 	// 2. execute bootstrap.sh
-	if output, err := self.executeSSH(REMOTE_TARGET_PATH+"/bootstrap.sh %s %s %s %s %s", self.CSP, self.Region, self.Name, self.PublicIP, networkCni); err != nil {
+	if output, err := self.executeSSH(REMOTE_TARGET_PATH+"/bootstrap.sh %s %s %s %s", self.CSP, self.Name, self.PublicIP, networkCni); err != nil {
 		return errors.New(fmt.Sprintf("Failed to execute bootstrap.sh (node=%s)", self.Name))
 	} else if !strings.Contains(output, "kubectl set on hold") {
 		return errors.New(fmt.Sprintf("Failed to execute bootstrap.sh shell. (node=%s, cause='kubectl not set on hold')", self.Name))

--- a/src/core/provision/types.go
+++ b/src/core/provision/types.go
@@ -16,6 +16,7 @@ const (
 type Machine struct {
 	Name       string
 	PublicIP   string
+	PrivateIP  string
 	Username   string
 	CSP        app.CSP
 	Role       app.ROLE

--- a/src/core/service/csp.go
+++ b/src/core/service/csp.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"strings"
 
 	"github.com/cloud-barista/cb-mcks/src/core/app"
@@ -54,8 +55,31 @@ var ibmImageMap = map[string]string{
 	"jp-tok":   "r022-61fdadec-6b03-4bd2-bfca-62cd16f5673f", //일본 (도쿄)
 }
 
-// get vm image-id
-func GetVmImageId(csp app.CSP, configName string, region *tumblebug.Region) (string, error) {
+// get a cidr-block
+func getCSPCidrBlock(csp app.CSP) string {
+
+	switch csp {
+	case app.CSP_AWS:
+		return fmt.Sprintf("192.168.%d.0/24", 10+rand.Intn(10))
+	case app.CSP_GCP:
+		return fmt.Sprintf("192.168.%d.0/24", 20+rand.Intn(10))
+	case app.CSP_AZURE:
+		return fmt.Sprintf("192.168.%d.0/24", 30+rand.Intn(10))
+	case app.CSP_ALIBABA:
+		return fmt.Sprintf("192.168.%d.0/24", 40+rand.Intn(10))
+	case app.CSP_TENCENT:
+		return fmt.Sprintf("192.168.%d.0/24", 50+rand.Intn(10))
+	case app.CSP_IBM:
+		return fmt.Sprintf("192.168.%d.0/24", 60+rand.Intn(10))
+	case app.CSP_OPENSTACK:
+		return fmt.Sprintf("192.168.%d.0/24", 70+rand.Intn(10))
+	}
+
+	return fmt.Sprintf("192.168.255.0/24")
+}
+
+// get a vm-image-id
+func getCSPImageId(csp app.CSP, configName string, region *tumblebug.Region) (string, error) {
 
 	if csp == app.CSP_GCP {
 		return GCP_IMAGE_ID, nil

--- a/src/core/service/node.go
+++ b/src/core/service/node.go
@@ -149,7 +149,7 @@ func AddNode(namespace string, clusterName string, req *app.NodeReq) (*model.Nod
 	logger.Infof("[%s.%s] Woker-nodes join has been completed.", namespace, clusterName)
 
 	// assign node labels (topology.cloud-barista.github.io/csp , topology.kubernetes.io/region, topology.kubernetes.io/zone)
-	if err = provisioner.AssignNodeLabels(); err != nil {
+	if err = provisioner.AssignNodeLabelAnnotation(); err != nil {
 		logger.Warnf("[%s.%s] Failed to assign node labels (cause='%v')", namespace, clusterName, err)
 	} else {
 		logger.Infof("[%s.%s] Node label assignment has been completed.", namespace, clusterName)

--- a/src/core/tumblebug/mcir.go
+++ b/src/core/tumblebug/mcir.go
@@ -9,16 +9,16 @@ import (
 )
 
 /* new instance of VPC */
-func NewVPC(ns string, name string, conf string) *VPC {
+func NewVPC(ns string, name string, conf string, cidrBlock string) *VPC {
 
 	return &VPC{
 		Model:     Model{Name: name, Namespace: ns},
 		Config:    conf,
-		CidrBlock: "192.168.0.0/16",
+		CidrBlock: cidrBlock,
 		Subnets: []Subnet{
 			{
 				Name:      fmt.Sprintf("%s-subnet", conf),
-				CidrBlock: "192.168.1.0/24"},
+				CidrBlock: cidrBlock},
 		},
 	}
 }


### PR DESCRIPTION
**현상**

* 멀티 VPC 를 환경에 설치되는 클러스터 생성 시 network-cni 설치 후 etcd shutdown 되는 현상 발생
* 이슈 : #123 

**원인**

* VM의 private-ip 중복으로 인한 network-cni 오동작이  원인
* VM IP 채번 방식  (Tumblebug)
  * VPC 생성 요청 시 지정된 cidr-block 내에서 채번
  * 채번방식 2종 - 랜덤 채번 방식은 AWS, Alibaba,  순서 채번 방식은 GCP, Azure, Tencent, IBM 
  * 순서 채번 방식은 IP가 순서대로 증가 (192.168.1.2, 192.168.1.3, 192.168.1.4, .....)
* 동일한 cidr-block 로 지정된 멀티 VPC(멀티 리전 or CSP)로 클러스터를 구성할 경우 채번방식에 따라 VM들의  private-ip 중복될 가능성


**검증 및 검토**

* Canal 인 경우 해당 네트워크 오버레이의 노드 IP를 public-ip 로 detect 되도록 지정하면 문제 해결
  * calico : `kubectl annotate node {{HOSTNAME}} projectcalico.org/IPv4Address=${PUBLIC_IP}`
  * flannel  : `kubectl annotate node {{HOSTNAME}} flannel.alpha.coreos.com/public-ip-overwrite=${PUBLIC_IP}`
* Kilo 경우는 private-ip 중복되면 반드시 문제 발생
  *  VPC 생성 시 중복되지 않는  cidr-block 지정 필요


**처리방법**

* Canal은 private-ip 중복되어도 상관 없도록 처리
* Kilo는 동일 private-ip 가 지정될 경우는 해결방법이 없으므로 VPC 생성 시 cidr-block이 중복되지 않도록 처리
* cidr-block 중복 제거 방법
  * CSP별 cidr-blcok 범위를 지정하여 CSP별 cidr-block 중복 가능성 제거
  * AWS : 192.168.10.0/24 ~ 192.168.19.0/24
  * GCP : 192.168.20.0/24 ~ 192.168.29.0/24
  * Azure : 192.168.30.0/24 ~ 192.168.39.0/24
  * Alibaba : 192.168.40.0/24 ~ 192.168.49.0/24
  * Tencent : 192.168.50.0/24 ~ 192.168.59.0/24
  * IBM : 192.168.60.0/24 ~ 192.168.69.0/24
  * OpenStack : 192.168.70.0/24 ~ 192.168.79.0/24
  * cidr-block 범위 내에서  랜덤하게 지정되도록 하여 중복 확률 낮춤
* 단일 CSP + 멀티 VPC  클러스터를 구성 시
  * 낮은 확률로 private-ip 중복 가능성 있음 
  * IP 중복 확률은  순서 채번 방식의 CSP(GCP,Azure, Tencent, IBM)에서 멀티 리전 VCP가 최초 생성 될 때 최대(1%)로 예상
  * 이 경우 Canal 선택을 권장

**추가 수정**

* haproxy 설정정보에서  LB 되는 서버 IP 구성이 public-ip 로 지정된 부분 수정 > private-ip로 변경
* bootstrap.sh package 설치 시 output 내용 조정
  * debconf 로그 제거
* network-cni 설치 순서를  node labels & annotations 지정 이후로 변경
* 소스 개선
  * 중복 상수 제거
  * bootstrap.sh region 파라메터 제거

**Tested with**

* CB-Spider (https://github.com/cloud-barista/cb-spider/releases/tag/v0.5.0)
* CB-Tumblebug (https://github.com/cloud-barista/cb-tumblebug/releases/tag/v0.5.0)
* 주요내용 
  * gcp, azure, ibm 3개 CSP  총 7개 노드 기준 시험
  * Create a Cluster, Add nodes 처리 > 정상처리
  * etcd, api-server 정상동작 모니터링 > 확인완료
  * 멀티 CSP 노드 간 통신 > 확인완료



