### PR TITLE
feat:Implement 'get VM SpecList' API

### DIFF
--- a/src/core/service/type.go
+++ b/src/core/service/type.go
@@ -1,0 +1,16 @@
+package service
+
+type SpecList struct {
+	Kind    string    `json:"kind"`
+	Config  string    `json:"connectionName"`
+	Vmspecs []Vmspecs `json:"items"`
+}
+
+type Vmspecs struct {
+	Name   string `json:"name"`   // output
+	Memory string `json:"memory"` // output
+	CPU    struct {
+		Count string `json:"count"` // output
+		Clock string `json:"clock"` // output - GHz
+	} `json:"cpu"`
+}

--- a/src/core/tumblebug/mcir.go
+++ b/src/core/tumblebug/mcir.go
@@ -83,6 +83,14 @@ func NewLookupSpec(conf string, spec string) *LookupSpec {
 	}
 }
 
+/* new instance of VM-Specs-lookup */
+func NewLookupSpecs(conf string) *LookupSpecs {
+	return &LookupSpecs{
+		Model:  Model{Name: "conf"},
+		Config: conf,
+	}
+}
+
 /* new instance of SSH-Key */
 func NewSSHKey(ns string, name string, conf string) *SSHKey {
 	return &SSHKey{
@@ -280,5 +288,11 @@ func (self *LookupImages) GET() (bool, error) {
 func (spec *LookupSpec) GET() (bool, error) {
 
 	return spec.execute(http.MethodPost, "/lookupSpec", spec, &spec)
+
+}
+
+func (spec *LookupSpecs) GET() (bool, error) {
+
+	return spec.execute(http.MethodPost, "/lookupSpecs", spec, &spec)
 
 }

--- a/src/core/tumblebug/types.go
+++ b/src/core/tumblebug/types.go
@@ -122,6 +122,19 @@ type LookupSpec struct {
 	} `json:"vcpu"`
 }
 
+type LookupSpecs struct {
+	Model
+	Config  string `json:"connectionName"`
+	Vmspecs []struct {
+		Name   string `json:"name"` // output
+		Memory string `json:"mem"`  // output
+		CPU    struct {
+			Count string `json:"count"` // output
+			Clock string `json:"clock"` // output - GHz
+		} `json:"vcpu"`
+	} `json:"vmspec"`
+}
+
 type LookupImages struct {
 	Model
 	ConnectionName string `json:"connectionName"`

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -56,6 +56,86 @@ var doc = `{
                 }
             }
         },
+        "/mcir/connections/{connection}/specs": {
+            "get": {
+                "description": "List Specs",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Mcir"
+                ],
+                "summary": "List Specs",
+                "operationId": "List Spec",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection Name",
+                        "name": "connection",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "Y",
+                            "N"
+                        ],
+                        "type": "string",
+                        "description": "string enums",
+                        "name": "control-plane",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "if Control-Plane, \u003e= 2",
+                        "name": "cpu-min",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 99999,
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": " \u003c= 99999",
+                        "name": "cpu-max",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": " if Control-Plane, \u003e= 2",
+                        "name": "memory-min",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 99999,
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": " \u003c= 99999",
+                        "name": "memory-max",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.SpecList"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/app.Status"
+                        }
+                    }
+                }
+            }
+        },
         "/ns/{namespace}/clusters": {
             "get": {
                 "description": "List all Clusters",
@@ -731,6 +811,49 @@ var doc = `{
                     }
                 },
                 "kind": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.SpecList": {
+            "type": "object",
+            "properties": {
+                "connectionName": {
+                    "type": "string"
+                },
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.VM"
+                    }
+                },
+                "kind": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.VM": {
+            "type": "object",
+            "properties": {
+                "cpu": {
+                    "type": "object",
+                    "properties": {
+                        "clock": {
+                            "description": "output - GHz",
+                            "type": "string"
+                        },
+                        "count": {
+                            "description": "output",
+                            "type": "string"
+                        }
+                    }
+                },
+                "memory": {
+                    "description": "output",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "output",
                     "type": "string"
                 }
             }

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -41,6 +41,86 @@
                 }
             }
         },
+        "/mcir/connections/{connection}/specs": {
+            "get": {
+                "description": "List Specs",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Mcir"
+                ],
+                "summary": "List Specs",
+                "operationId": "List Spec",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection Name",
+                        "name": "connection",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "Y",
+                            "N"
+                        ],
+                        "type": "string",
+                        "description": "string enums",
+                        "name": "control-plane",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "if Control-Plane, \u003e= 2",
+                        "name": "cpu-min",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 99999,
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": " \u003c= 99999",
+                        "name": "cpu-max",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": " if Control-Plane, \u003e= 2",
+                        "name": "memory-min",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 99999,
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": " \u003c= 99999",
+                        "name": "memory-max",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.SpecList"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/app.Status"
+                        }
+                    }
+                }
+            }
+        },
         "/ns/{namespace}/clusters": {
             "get": {
                 "description": "List all Clusters",
@@ -722,6 +802,49 @@
                     }
                 },
                 "kind": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.SpecList": {
+            "type": "object",
+            "properties": {
+                "connectionName": {
+                    "type": "string"
+                },
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.VM"
+                    }
+                },
+                "kind": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.VM": {
+            "type": "object",
+            "properties": {
+                "cpu": {
+                    "type": "object",
+                    "properties": {
+                        "clock": {
+                            "description": "output - GHz",
+                            "type": "string"
+                        },
+                        "count": {
+                            "description": "output",
+                            "type": "string"
+                        }
+                    }
+                },
+                "memory": {
+                    "description": "output",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "output",
                     "type": "string"
                 }
             }

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -185,6 +185,35 @@ definitions:
       kind:
         type: string
     type: object
+  model.SpecList:
+    properties:
+      connectionName:
+        type: string
+      items:
+        items:
+          $ref: '#/definitions/model.VM'
+        type: array
+      kind:
+        type: string
+    type: object
+  model.VM:
+    properties:
+      cpu:
+        properties:
+          clock:
+            description: output - GHz
+            type: string
+          count:
+            description: output
+            type: string
+        type: object
+      memory:
+        description: output
+        type: string
+      name:
+        description: output
+        type: string
+    type: object
 host: localhost:1470
 info:
   contact:
@@ -214,6 +243,62 @@ paths:
       summary: Health Check
       tags:
       - Default
+  /mcir/connections/{connection}/specs:
+    get:
+      consumes:
+      - application/json
+      description: List Specs
+      operationId: List Spec
+      parameters:
+      - description: Connection Name
+        in: path
+        name: connection
+        required: true
+        type: string
+      - description: string enums
+        enum:
+        - "Y"
+        - "N"
+        in: query
+        name: control-plane
+        required: true
+        type: string
+      - description: if Control-Plane, >= 2
+        in: query
+        minimum: 1
+        name: cpu-min
+        type: integer
+      - description: ' <= 99999'
+        in: query
+        maximum: 99999
+        minimum: 1
+        name: cpu-max
+        type: integer
+      - description: ' if Control-Plane, >= 2'
+        in: query
+        minimum: 1
+        name: memory-min
+        type: integer
+      - description: ' <= 99999'
+        in: query
+        maximum: 99999
+        minimum: 1
+        name: memory-max
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.SpecList'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/app.Status'
+      summary: List Specs
+      tags:
+      - Mcir
   /ns/{namespace}/clusters:
     get:
       consumes:

--- a/src/rest-api/router/mcir.go
+++ b/src/rest-api/router/mcir.go
@@ -1,0 +1,67 @@
+package router
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/cloud-barista/cb-mcks/src/core/app"
+	"github.com/cloud-barista/cb-mcks/src/core/service"
+	"github.com/labstack/echo/v4"
+	logger "github.com/sirupsen/logrus"
+)
+
+// ListSpec godoc
+// @Tags Mcir
+// @Summary List Specs
+// @Description List Specs
+// @ID List Spec
+// @Accept json
+// @Produce json
+// @Param	connection	path	string		true  "Connection Name"
+// @Param   control-plane  query    string    	true  "string enums"       Enums(Y, N)
+// @Param   cpu-min     query     int        	false  "if Control-Plane, >= 2"           minimum(1)
+// @Param   cpu-max     query     int        	false  " <= 99999"          minimum(1)    maximum(99999)
+// @Param   memory-min     query     int        false  " if Control-Plane, >= 2"          minimum(1)
+// @Param   memory-max     query     int        false  " <= 99999"          minimum(1)    maximum(99999)
+// @Success 200 {object} model.SpecList
+// @Failure 400 {object} app.Status
+// @Router /mcir/connections/{connection}/specs [get]
+func ListSpec(c echo.Context) error {
+
+	controlPlane := c.QueryParam("control-plane")
+	if controlPlane == "" {
+		controlPlane = "N"
+	}
+	cpumin := validateSpec(c, "cpu-min")
+	memorymin := validateSpec(c, "memory-min")
+	cpumax := validateSpec(c, "cpu-max")
+	memorymax := validateSpec(c, "memory-max")
+
+	lookupSpecs, err := service.VerifySpecList(c.Param("connection"), controlPlane, cpumin, cpumax, memorymin, memorymax)
+
+	if err != nil {
+		logger.Warnf("(ListSpec) %s'", err.Error())
+		return app.SendMessage(c, http.StatusNotFound, err.Error())
+	}
+
+	return app.Send(c, http.StatusOK, lookupSpecs)
+}
+
+func validateSpec(c echo.Context, param string) int {
+	controlPlane := c.QueryParam("control-plane")
+	if c.QueryParam(param) == "" {
+		if strings.Contains(param, "min") {
+			if controlPlane == "Y" {
+				return 2
+			} else {
+				return 1
+			}
+		}
+		if strings.Contains(param, "max") {
+			return 99999
+		}
+	}
+	returnParam, _ := strconv.Atoi(c.QueryParam(param))
+	return returnParam
+}

--- a/src/rest-api/server.go
+++ b/src/rest-api/server.go
@@ -31,6 +31,10 @@ func Server() {
 
 	e.GET(*app.Config.RootURL+"/healthy", router.Healthy)
 
+	m := e.Group(*app.Config.RootURL + "/mcir/connections")
+
+	m.GET("/:connection/specs", router.ListSpec)
+
 	g := e.Group(*app.Config.RootURL+"/ns", validMiddlewareFunc())
 
 	// Routes


### PR DESCRIPTION
csp 별 운용 가능한 VM 스펙 조회 API 추가
- 이슈 : Implement API that provides VM specs that can be deployed and operated by CSP #127

 조회 조건 
 - 필수
   - connection Name
   - control-plane 여부 (미 입력시 worker 설정)
 - 추가  (미 입력 시 control-plane여부에 따른 최소값 강제 지정 )
   - cpu 최소/최대 값
   - memory 최소/최대 값
