### PR TITLE
fix:Insert swapoff into k8s 1.23 install script

### DIFF
--- a/src/scripts/bootstrap.sh
+++ b/src/scripts/bootstrap.sh
@@ -10,6 +10,7 @@ sudo hostnamectl set-hostname ${HOSTNAME}
 
 if [[ "${K8S_VERSION}" == "1.23"* ]]; then 
 
+sudo swapoff -a && sed -i '/swap/s/^/#/' /etc/fstab
 # br_netfilter
 sudo cat <<EOF | sudo tee /etc/modules-load.d/k8s.conf
 br_netfilter


### PR DESCRIPTION
- fix: Insert swapoff into k8s 1.23 install script
  - k8s 1.23 버전 설치시 csp: cloudit 일때 swapoff 필요

**Tested with**

- CB-Spider (https://github.com/cloud-barista/cb-spider/releases/tag/v0.5.12)
- CB-Tumblebug (https://github.com/cloud-barista/cb-tumblebug/releases/tag/v0.5.11)