### PR TITLE
docs: update for v0.6.0-cafelatte release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Cloud-Barista Multi-Cloud Kubernetes Service Framework (CB-MCKS) ChangeLog
 
+## v0.6.0 (CafeLatte, 2022.07.08.)
+
+### Tested with
+
+- CB-Spider (https://github.com/cloud-barista/cb-spider/releases/tag/v0.6.0)
+- CB-Tumblebug (https://github.com/cloud-barista/cb-tumblebug/releases/tag/v0.6.0)
+- CB-Dragonfly (https://github.com/cloud-barista/cb-dragonfly/releases/tag/v0.6.0)
+
+
+### API Change
+
+- Add support for k8s 1.23 version [#136](https://github.com/cloud-barista/cb-mcks/pull/136)
+- Improve a cbadm cli [#135](https://github.com/cloud-barista/cb-mcks/pull/135)
+
+### Feature
+
+- Add support for IBM-cloud [#119](https://github.com/cloud-barista/cb-mcks/pull/119)
+- Implement 'get VM SpecList' rest API  feature [#128](https://github.com/cloud-barista/cb-mcks/pull/128)
+- Implement 'get VM SpecList' gRPC API  feature [#129](https://github.com/cloud-barista/cb-mcks/pull/129)
+- Add support for Cloudit [#131](https://github.com/cloud-barista/cb-mcks/pull/131)
+- Add support for k8s 1.23 version [#136](https://github.com/cloud-barista/cb-mcks/pull/136)
+- Add a inline parameters to cbadm commands(create a cluster & add nodes) [#137](https://github.com/cloud-barista/cb-mcks/pull/137)
+
+### Bug Fix
+
+- Modify the worker-join process hang when creating a cluster by applying Kilo-CNI [#121](https://github.com/cloud-barista/cb-mcks/pull/121)
+- Duplicated private-ip problem on multiple VPCs [#124](https://github.com/cloud-barista/cb-mcks/pull/124)
+- Delete body for http get Method [#126](https://github.com/cloud-barista/cb-mcks/pull/126)
+- Bump github.com/beego/beego/v2 from 2.0.1 to 2.0.2 [#132](https://github.com/cloud-barista/cb-mcks/pull/132)
+- Insert swapoff into k8s 1.23 install script [#138](https://github.com/cloud-barista/cb-mcks/pull/138)
+
+### Refactoring
+
+- Improve a source structure [#122](https://github.com/cloud-barista/cb-mcks/pull/122)
+
+### Documentation
+
+- Tidy markdown documents [#118](https://github.com/cloud-barista/cb-mcks/pull/118)
+- Fix connectioninfo-create.sh 'CSP' add [#130](https://github.com/cloud-barista/cb-mcks/pull/130)
+
+
+### Note
+- Full Changelog: https://github.com/cloud-barista/cb-mcks/compare/v0.5.0...v0.6.0
+
+***
+
 ## v0.5.0 (Affogato, 2021.12.16.)
 
 ### Tested with

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ```
 [NOTE]
-CB-MCKS is currently under development. (The latest version is v0.5.0 (Affogato))
+CB-MCKS is currently under development. (The latest version is v0.6.0 (Cafe Latte))
 So, we do not recommend using the current release in production.
 Please note that the functionalities of CB-MCKS are not stable and secure yet.
 If you have any difficulties in using CB-MCKS, please let us know.
@@ -27,8 +27,8 @@ If you have any difficulties in using CB-MCKS, please let us know.
 
 ### Dependencies
 
-* CB-Tumblebug [v0.5.0](https://github.com/cloud-barista/cb-tumblebug/releases/tag/v0.5.0)
-* CB-Spider [v0.5.0](https://github.com/cloud-barista/cb-spider/releases/tag/v0.5.0)
+* CB-Tumblebug [v0.6.0](https://github.com/cloud-barista/cb-tumblebug/releases/tag/v0.6.0)
+* CB-Spider [v0.6.0](https://github.com/cloud-barista/cb-spider/releases/tag/v0.6.0)
 
 
 ### Clone

--- a/docs/design/cluster-create.puml
+++ b/docs/design/cluster-create.puml
@@ -1,6 +1,6 @@
 @startuml
 
-header **Cloud-Barista MCKS** (v0.5.0-affogato)
+header **Cloud-Barista MCKS** (v0.6.0-cafelatte)
 title Create a cluster
 hide footbox
 

--- a/docs/design/cluster-delete.puml
+++ b/docs/design/cluster-delete.puml
@@ -1,6 +1,6 @@
 @startuml
 
-header **Cloud-Barista MCKS** (v0.5.0-affogato)
+header **Cloud-Barista MCKS** (v0.6.0-cafelatte)
 title Delete a cluster
 hide footbox
 

--- a/docs/design/node-remove.puml
+++ b/docs/design/node-remove.puml
@@ -1,6 +1,6 @@
 @startuml
 
-header **Cloud-Barista MCKS** (v0.5.0-affogato)
+header **Cloud-Barista MCKS** (v0.6.0-cafelatte)
 title Remove a node
 hide footbox
 

--- a/docs/design/nodes-add.puml
+++ b/docs/design/nodes-add.puml
@@ -1,6 +1,6 @@
 @startuml
 
-header **Cloud-Barista MCKS** (v0.5.0-affogato)
+header **Cloud-Barista MCKS** (v0.6.0-cafelatte)
 title Add nodes
 hide footbox
 

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,9 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/beego/beego/v2 v2.0.2
 	github.com/cloud-barista/cb-log v0.5.0
-	github.com/cloud-barista/cb-spider v0.4.19
+	github.com/cloud-barista/cb-spider v0.5.0
 	github.com/cloud-barista/cb-store v0.5.0
-	github.com/cloud-barista/cb-tumblebug v0.4.18
+	github.com/cloud-barista/cb-tumblebug v0.5.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -243,13 +243,14 @@ github.com/cloud-barista/cb-log v0.4.0/go.mod h1:C0KNV97sw8IoLSlNuSiCGDQIuS/wXJa
 github.com/cloud-barista/cb-log v0.5.0 h1:WoUnXtNNNTA7wRgQa6sFNs57O3mLAOrh4aDHC4cU0CI=
 github.com/cloud-barista/cb-log v0.5.0/go.mod h1:C0KNV97sw8IoLSlNuSiCGDQIuS/wXJaZWV/6MOwc20c=
 github.com/cloud-barista/cb-spider v0.4.5/go.mod h1:/6DT/uHT/XEN6pm3Ne89awbjrFBJl8PE6F3i8T4SW/Y=
-github.com/cloud-barista/cb-spider v0.4.19 h1:Ovl99GVV7fElKQEyy+e9ILhJ9kmECis78603loaVisY=
 github.com/cloud-barista/cb-spider v0.4.19/go.mod h1:QhEE8dYh0xUvi4tSyxrbIZn1TzCwpDfFQTVTYIGlS6s=
+github.com/cloud-barista/cb-spider v0.5.0 h1:klEKNixTInlZhZnjzcDb1u9hqB05EQ5ftPqlZwJyeHE=
+github.com/cloud-barista/cb-spider v0.5.0/go.mod h1:QhEE8dYh0xUvi4tSyxrbIZn1TzCwpDfFQTVTYIGlS6s=
 github.com/cloud-barista/cb-store v0.4.1/go.mod h1:d3mwxDF2gC4lc7a+DFc2eo1OqqS9sHygLGUrU94hhj0=
 github.com/cloud-barista/cb-store v0.5.0 h1:1pqgmon1CQWQvjalm23K15G23qhP9hMoy9AUb8tn7bs=
 github.com/cloud-barista/cb-store v0.5.0/go.mod h1:EhuQfTQRoLPE6jCMMRGbM4OEIZv+Zk2Zf6wxsJ5GyEM=
-github.com/cloud-barista/cb-tumblebug v0.4.18 h1:JnMHvQCYn+kHu5ZjL/+kLeR+7ZnIGXQEx4XwXguBF+I=
-github.com/cloud-barista/cb-tumblebug v0.4.18/go.mod h1:98ttfmX1/krEx2oKFuCYBqiT5AG1H6cQSPVPfk8st9A=
+github.com/cloud-barista/cb-tumblebug v0.5.0 h1:x2JJc17PSvtIjeeq3q68vk2HeoYCddkkVo7wnBVoHnA=
+github.com/cloud-barista/cb-tumblebug v0.5.0/go.mod h1:98ttfmX1/krEx2oKFuCYBqiT5AG1H6cQSPVPfk8st9A=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=


### PR DESCRIPTION
- docs: update for v0.6.0-cafelatte release
  - go.mod
  - README.md
  - CHANGELOG.md
  - design documents

**Tested with**

- CB-Spider (https://github.com/cloud-barista/cb-spider/releases/tag/v0.5.12-p1)
- CB-Tumblebug (https://github.com/cloud-barista/cb-tumblebug/releases/tag/v0.5.11)