### PR TITLE
fix:Add GuestOs to openstack image search condition

### DIFF
--- a/src/core/service/csp.go
+++ b/src/core/service/csp.go
@@ -105,8 +105,11 @@ func getCSPImageId(csp app.CSP, configName string, region *tumblebug.Region) (st
 
 		for _, image := range lookupImages.Images {
 			id := strings.ToLower(lang.GetOnlyLettersAndNumbers(image.IId.NameId))
+			guestOs := strings.ToLower(lang.GetOnlyLettersAndNumbers(image.GuestOS))
 			if strings.Contains(id, "ubuntu") && strings.Contains(id, "1804") {
 				return image.IId.NameId, nil
+			} else if strings.Contains(guestOs, "ubuntu") && strings.Contains(guestOs, "1804") {
+				return image.GuestOS, nil
 			}
 		}
 


### PR DESCRIPTION
- fix:Add GuestOs to openstack image search condition
  - openstack 버전만 다른 환경에서 기존 항목에 다른 값이 들어오는 현상으로 인해 추가.

**Tested with**

- CB-Spider (https://github.com/cloud-barista/cb-spider/releases/tag/v0.6.4)
- CB-Tumblebug (https://github.com/cloud-barista/cb-tumblebug/releases/tag/v0.6.0)