### PR TITLE
feat:Add support for loadbalancer NLB

### DIFF
--- a/docs/design/entity.md
+++ b/docs/design/entity.md
@@ -22,6 +22,7 @@
     networkCni: "",
     label: "",
     installMonAgent: "",
+    loadbalancer: ""
     k8sVersion: "",
     description: "",
     createdTime: "",
@@ -73,6 +74,7 @@
 |cpLeader           |control plane leader 노드명   |string |                                     |
 |networkCni         |network CNI 정보             |string |                                     |
 |label              |label                       |string |                                     |
+|loadbalancer       |loadbalancer                |string |                                     |
 |installMonAgent    |모니터링 에이전트 설치 여부        |string | yes/no (no가 아니면 설치)              |
 |description        |description                 |string |                                     |
 |createdTime        |생성일자                      |string |                                     |

--- a/docs/test/cluster-create.sh
+++ b/docs/test/cluster-create.sh
@@ -53,6 +53,7 @@ create() {
 			"name": "${v_CLUSTER_NAME}",
 			"label": "",
 			"installMonAgent": "",
+			"loadbalancer": "",
 			"description": "",
 			"config": {
 				"kubernetes": {

--- a/docs/test/mcir-delete.sh
+++ b/docs/test/mcir-delete.sh
@@ -2,7 +2,7 @@
 # ------------------------------------------------------------------------------
 # usage
 if [ "$#" -lt 1 ]; then 
-	echo "./mcir-delete.sh <namespace> [all/image/spec/ssh/sg/vpc]"
+	echo "./mcir-delete.sh <namespace> [all/image/spec/ssh/sg/nlb/vpc]"
 	echo "./mcir-delete.sh cb-mcks-ns all"
 	exit 0
 fi
@@ -28,10 +28,10 @@ if [ "${v_NAMESPACE}" == "" ]; then echo "[ERROR] missing <namespace>"; exit -1;
 # 2. query
 if [ "$#" -gt 1 ]; then v_QUERY="$2"; fi
 if [ "${v_QUERY}" == "" ]; then 
-	read -e -p "Query ? [all/image/spec/ssh/sg/vpc] : "  v_QUERY
+	read -e -p "Query ? [all/image/spec/ssh/sg/nlb/vpc] : "  v_QUERY
 fi
 if [ "${v_QUERY}" == "" ]; then echo "[ERROR] missing <query>"; exit -1; fi
-if [ "${v_QUERY}" == "all" ]; then v_QUERY="image,spec,ssh,sg,vpc"; fi
+if [ "${v_QUERY}" == "all" ]; then v_QUERY="image,spec,ssh,sg,nlb,vpc"; fi
 
 
 # ------------------------------------------------------------------------------
@@ -55,8 +55,11 @@ delete() {
 	if [[ "${v_QUERY}" == *"ssh"* ]]; then	echo "@_SSHKEY_@";		curl -sX DELETE ${NM_TUMBLEBUG_NS}/resources/sshKey   -H "${c_AUTH}" -H "${c_CT}" -o /dev/null -w "SSHKEY.delete():%{http_code}\n"; fi
 	# securityGroup
 	if [[ "${v_QUERY}" == *"sg"* ]]; then	echo "@_SECURITYGROUP_@";		curl -sX DELETE ${NM_TUMBLEBUG_NS}/resources/securityGroup   -H "${c_AUTH}" -H "${c_CT}" -o /dev/null -w "SECURITYGROUP.delete():%{http_code}\n"; fi
+	# nlb
+	if [[ "${v_QUERY}" == *"nlb"* ]]; then	echo "@_NLB_@";		curl -sX DELETE ${NM_TUMBLEBUG_NS}/nlb   -H "${c_AUTH}" -H "${c_CT}" -o /dev/null -w "NLB.delete():%{http_code}\n"; fi
 	# vpc
 	if [[ "${v_QUERY}" == *"vpc"* ]]; then	echo "@_VPC_@";		curl -sX DELETE ${NM_TUMBLEBUG_NS}/resources/vNet   -H "${c_AUTH}" -H "${c_CT}" -o /dev/null -w "VNET.delete():%{http_code}\n"; fi
+	
 
 }
 
@@ -68,6 +71,7 @@ show() {
 	if [[ "${v_QUERY}" == *"spec"* ]]; then echo "SPEC";      curl -sX GET ${NM_TUMBLEBUG_NS}/resources/spec   -H "${c_AUTH}" -H "${c_CT}" | jq; fi
 	if [[ "${v_QUERY}" == *"ssh"* ]]; then	echo "SSHKEY";     curl -sX GET ${NM_TUMBLEBUG_NS}/resources/sshKey   -H "${c_AUTH}"	-H "${c_CT}" | jq; fi
 	if [[ "${v_QUERY}" == *"sg"* ]]; then	echo "SECURITYGROUP";     curl -sX GET ${NM_TUMBLEBUG_NS}/resources/securityGroup   -H "${c_AUTH}"	-H "${c_CT}" | jq; fi
+	if [[ "${v_QUERY}" == *"nlb"* ]]; then	echo "NLB";     curl -sX GET ${NM_TUMBLEBUG_NS}/nlb   -H "${c_AUTH}" -H "${c_AUTH}" -H "${c_CT}" | jq; fi
 	if [[ "${v_QUERY}" == *"vpc"* ]]; then	echo "VPC";     curl -sX GET ${NM_TUMBLEBUG_NS}/resources/vNet   -H "${c_AUTH}" -H "${c_AUTH}" -H "${c_CT}" | jq; fi
 }
 

--- a/docs/test/mcir-list.sh
+++ b/docs/test/mcir-list.sh
@@ -2,7 +2,7 @@
 # ------------------------------------------------------------------------------
 # usage
 if [ "$#" -lt 1 ]; then 
-	echo "./mcir-list.sh <namespace> [all/image/spec/ssh/sg/vpc]"
+	echo "./mcir-list.sh <namespace> [all/image/spec/ssh/sg/vpc/nlb]"
 	echo "./mcir-list.sh cb-mcks-ns all"
 	exit 0
 fi
@@ -26,10 +26,10 @@ if [ "${v_NAMESPACE}" == "" ]; then echo "[ERROR] missing <namespace>"; exit -1;
 # 2. query
 if [ "$#" -gt 1 ]; then v_QUERY="$2"; fi
 if [ "${v_QUERY}" == "" ]; then 
-	read -e -p "Query ? [all/image/spec/ssh/sg/vpc] : "  v_QUERY
+	read -e -p "Query ? [all/image/spec/ssh/sg/vpc/nlb] : "  v_QUERY
 fi
 if [ "${v_QUERY}" == "" ]; then echo "[ERROR] missing <query>"; exit -1; fi
-if [ "${v_QUERY}" == "all" ]; then v_QUERY="image,spec,ssh,sg,vpc"; fi
+if [ "${v_QUERY}" == "all" ]; then v_QUERY="image,spec,ssh,sg,vpc,nlb"; fi
 
 
 # ------------------------------------------------------------------------------
@@ -50,6 +50,7 @@ list() {
 	if [[ "${v_QUERY}" == *"ssh"* ]]; then	echo "SSHKEY";     curl -sX GET ${NM_TUMBLEBUG_NS}/resources/sshKey   -H "${c_AUTH}"	-H "${c_CT}" | jq; fi
 	if [[ "${v_QUERY}" == *"sg"* ]]; then	echo "SECURITYGROUP";     curl -sX GET ${NM_TUMBLEBUG_NS}/resources/securityGroup   -H "${c_AUTH}"	-H "${c_CT}" | jq; fi
 	if [[ "${v_QUERY}" == *"vpc"* ]]; then	echo "VPC";     curl -sX GET ${NM_TUMBLEBUG_NS}/resources/vNet   -H "${c_AUTH}" -H "${c_AUTH}" -H "${c_CT}" | jq; fi
+	if [[ "${v_QUERY}" == *"nlb"* ]]; then	echo "NLB";     curl -sX GET ${NM_TUMBLEBUG_NS}/nlb   -H "${c_AUTH}" -H "${c_AUTH}" -H "${c_CT}" | jq; fi
 }
 
 # ------------------------------------------------------------------------------

--- a/src/core/app/ack.go
+++ b/src/core/app/ack.go
@@ -60,7 +60,9 @@ func ClusterReqValidate(req ClusterReq) error {
 	if !(req.Config.Kubernetes.NetworkCni == NETWORKCNI_CANAL || req.Config.Kubernetes.NetworkCni == NETWORKCNI_KILO) {
 		return errors.New("Network-cni allows only canal or kilo")
 	}
-
+	if len(req.Loadbalancer) != 0 && !(req.Loadbalancer == LB_HAPROXY || req.Loadbalancer == LB_NLB) {
+		return errors.New("loadbalancer allows only haproxy or nlb")
+	}
 	if len(req.Name) == 0 {
 		return errors.New("Cluster name is empty")
 	} else {

--- a/src/core/app/const.go
+++ b/src/core/app/const.go
@@ -32,6 +32,9 @@ const (
 	NETWORKCNI_KILO  NetworkCni = "kilo"
 	NETWORKCNI_CANAL NetworkCni = "canal"
 
+	LB_HAPROXY = "haproxy"
+	LB_NLB     = "nlb"
+
 	POD_CIDR       = "10.244.0.0/16"
 	SERVICE_CIDR   = "10.96.0.0/12"
 	SERVICE_DOMAIN = "cluster.local"
@@ -58,6 +61,7 @@ type ClusterReq struct {
 	StorageClass    ClusterStorageClassReq `json:"storageclass"`
 	Label           string                 `json:"label"`
 	InstallMonAgent string                 `json:"installMonAgent" example:"no" default:"yes"`
+	Loadbalancer    string                 `json:"loadbalancer" example:"haproxy" default:"haproxy"`
 	Description     string                 `json:"description"`
 }
 

--- a/src/core/model/types.go
+++ b/src/core/model/types.go
@@ -25,6 +25,7 @@ const (
 	CreateSSHKeyFailedReason                  = ClusterReason("CreateSSHKeyFailedReason")
 	CreateVmImageFailedReason                 = ClusterReason("CreateVmImageFailedReason")
 	CreateVmSpecFailedReason                  = ClusterReason("CreateVmSpecFailedReason")
+	CreateNLBFailedReason                     = ClusterReason("CreateNLBFailedReason")
 	AddNodeEntityFailedReason                 = ClusterReason("AddNodeEntityFailedReason")
 	SetupBoostrapFailedReason                 = ClusterReason("SetupBoostrapFailedReason")
 	SetupHaproxyFailedReason                  = ClusterReason("SetupHaproxyFailedReason")
@@ -54,6 +55,7 @@ type Cluster struct {
 	NetworkCni      app.NetworkCni `json:"networkCni" enums:"canal,kilo"`
 	Label           string         `json:"label"`
 	InstallMonAgent string         `json:"installMonAgent" example:"no" default:"yes"`
+	Loadbalancer    string         `json:"loadbalancer" example:"haproxy" default:"haproxy"`
 	Description     string         `json:"description"`
 	CreatedTime     string         `json:"createdTime" example:"2022-01-02T12:00:00Z" default:""`
 	Nodes           []*Node        `json:"nodes"`

--- a/src/core/provision/provisioner.go
+++ b/src/core/provision/provisioner.go
@@ -167,8 +167,13 @@ func (self *Provisioner) InstallHAProxy() error {
 func (self *Provisioner) InitControlPlane(kubernetesConfigReq app.ClusterConfigKubernetesReq) ([]string, string, error) {
 
 	var joinCmd []string
-
-	if output, err := self.leader.executeSSH("cd %s;./%s %s %s %s %s", REMOTE_TARGET_PATH, "k8s-init.sh", kubernetesConfigReq.PodCidr, kubernetesConfigReq.ServiceCidr, kubernetesConfigReq.ServiceDnsDomain, self.leader.PublicIP); err != nil {
+	var port string
+	if self.Cluster.Loadbalancer == app.LB_HAPROXY {
+		port = "9998"
+	} else {
+		port = "6443"
+	}
+	if output, err := self.leader.executeSSH("cd %s;./%s %s %s %s %s %s", REMOTE_TARGET_PATH, "k8s-init.sh", kubernetesConfigReq.PodCidr, kubernetesConfigReq.ServiceCidr, kubernetesConfigReq.ServiceDnsDomain, self.leader.PublicIP, port); err != nil {
 		return nil, "", errors.New("Failed to initialize control-plane. (k8s-init.sh)")
 	} else if strings.Contains(output, "Your Kubernetes control-plane has initialized successfully") {
 		joinCmd = getJoinCmd(output)

--- a/src/core/service/csp.go
+++ b/src/core/service/csp.go
@@ -16,7 +16,7 @@ const (
 	AZURE_IMAGE_ID   = "Canonical:UbuntuServer:18.04-LTS:latest"
 	ALIBABA_IMAGE_ID = "ubuntu_18_04_x64_20G_alibase_20210521.vhd"
 	TENCENT_IMAGE_ID = "img-pi0ii46r"
-	CLOUDIT_IMAGE_ID = "Ubuntu 18.04"
+	CLOUDIT_IMAGE_ID = "ac2696a8-ecf7-4aab-bfbf-9ab5f3256ca2"
 )
 
 // region별 AMI :  (AMI 이름 : ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200908, 소유자:099720109477 )
@@ -106,10 +106,8 @@ func getCSPImageId(csp app.CSP, configName string, region *tumblebug.Region) (st
 		for _, image := range lookupImages.Images {
 			id := strings.ToLower(lang.GetOnlyLettersAndNumbers(image.IId.NameId))
 			guestOs := strings.ToLower(lang.GetOnlyLettersAndNumbers(image.GuestOS))
-			if strings.Contains(id, "ubuntu") && strings.Contains(id, "1804") {
+			if (strings.Contains(id, "ubuntu") && strings.Contains(id, "1804")) || (strings.Contains(guestOs, "ubuntu") && strings.Contains(guestOs, "1804")) {
 				return image.IId.NameId, nil
-			} else if strings.Contains(guestOs, "ubuntu") && strings.Contains(guestOs, "1804") {
-				return image.GuestOS, nil
 			}
 		}
 

--- a/src/core/service/mcir.go
+++ b/src/core/service/mcir.go
@@ -22,6 +22,7 @@ type MCIR struct {
 	spec         string //prameter
 	vmCount      int    //prameter
 	credential   string
+	nlbName      string
 	subnetName   string
 	vpcName      string
 	firewallName string
@@ -42,6 +43,7 @@ func NewMCIR(namespace string, role app.ROLE, nodeSetReq app.NodeSetReq) *MCIR {
 		config:       nodeSetReq.Connection,
 		spec:         nodeSetReq.Spec,
 		vmCount:      nodeSetReq.Count,
+		nlbName:      fmt.Sprintf("%s-nlb", nodeSetReq.Connection),
 		vpcName:      fmt.Sprintf("%s-vpc", nodeSetReq.Connection),
 		firewallName: fmt.Sprintf("%s-sg", nodeSetReq.Connection),
 		sshkeyName:   fmt.Sprintf("%s-sshkey", nodeSetReq.Connection),
@@ -193,6 +195,12 @@ func (self *MCIR) NewVM(namespace string, name string, mcisName string) tumblebu
 	vm.Image = self.imageName
 	vm.Spec = self.specName
 	return *vm
+}
+
+func (self *MCIR) NewNLB(namespace string, mcisName string) tumblebug.NLBReq {
+	nlb := tumblebug.NewNLB(namespace, self.nlbName, self.config, mcisName)
+	nlb.VPC = self.vpcName
+	return *nlb
 }
 
 /* verify - cpus & momories & look-up(exists) */

--- a/src/core/tumblebug/mcir.go
+++ b/src/core/tumblebug/mcir.go
@@ -3,6 +3,7 @@ package tumblebug
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/beego/beego/v2/core/validation"
 	"github.com/cloud-barista/cb-mcks/src/core/app"
@@ -37,11 +38,8 @@ func NewFirewall(csp app.CSP, ns string, name string, conf string) *Firewall {
 	if csp == app.CSP_TENCENT {
 		fw.FirewallRules = append(fw.FirewallRules,
 			FirewallRules{Protocol: "icmp", Direction: "inbound", From: "ALL"},
-			FirewallRules{Protocol: "ALL", Direction: "outbound", From: "ALL"},
 		)
-	} else if csp == app.CSP_CLOUDIT {
-		fw.FirewallRules = append(fw.FirewallRules, FirewallRules{Protocol: "ALL", Direction: "outbound", From: "ALL"})
-	} else {
+	} else if csp != app.CSP_CLOUDIT {
 		fw.FirewallRules = append(fw.FirewallRules, FirewallRules{Protocol: "icmp", Direction: "inbound", From: "-1", To: "-1"})
 	}
 
@@ -100,6 +98,34 @@ func NewSSHKey(ns string, name string, conf string) *SSHKey {
 		Config:   conf,
 		Username: VM_USER_ACCOUNT,
 	}
+}
+
+/* new instance of NLB */
+func NewNLB(ns string, name string, conf string, mcisName string) *NLBReq {
+	nlb := &NLBReq{
+		NLBBase: NLBBase{
+			Model:  Model{Name: name, Namespace: ns},
+			Config: conf,
+			Type:   "PUBLIC",
+			Scope:  "REGION", Listener: NLBProtocolBase{Protocol: "TCP", Port: "6443"},
+			TargetGroup: TargetGroup{NLBProtocolBase: NLBProtocolBase{Protocol: "TCP", Port: "6443"}, MCIS: mcisName},
+		},
+		HealthChecker: HealthCheckReq{
+			NLBProtocolBase: NLBProtocolBase{Protocol: "TCP", Port: "22"},
+			Interval:        "10", Threshold: "3",
+		},
+	}
+
+	if !strings.Contains(nlb.NLBBase.Config, string(app.CSP_AWS)) && !strings.Contains(nlb.NLBBase.Config, string(app.CSP_AZURE)) {
+		nlb.HealthChecker.Timeout = "9"
+	}
+
+	if strings.Contains(nlb.NLBBase.Config, string(app.CSP_GCP)) {
+		nlb.HealthChecker.NLBProtocolBase.Protocol = "HTTP"
+		nlb.HealthChecker.NLBProtocolBase.Port = "80"
+	}
+
+	return nlb
 }
 
 /* VPC */
@@ -297,4 +323,38 @@ func (spec *LookupSpecs) GET() (bool, error) {
 
 	return spec.execute(http.MethodPost, "/lookupSpecs", spec, &spec)
 
+}
+
+// NLB
+func (self *NLBReq) GET() (bool, error) {
+
+	return self.execute(http.MethodGet, fmt.Sprintf("/ns/%s/nlb/%s", self.Namespace, self.Name), nil, &self)
+
+}
+
+func (self *NLBReq) POST() error {
+
+	NLBRes := new(NLBRes)
+
+	_, err := self.execute(http.MethodPost, fmt.Sprintf("/ns/%s/nlb", self.Namespace), self, &NLBRes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (self *NLBReq) DELETE() (bool, error) {
+	exist, err := self.GET()
+	if err != nil {
+		return exist, err
+	}
+	if exist {
+		_, err := self.execute(http.MethodDelete, fmt.Sprintf("/ns/%s/nlb/%s", self.Namespace, self.Name), fmt.Sprintf(`{"connectionName" : "%s"}`, self.Config), app.Status{})
+		if err != nil {
+			return exist, err
+		}
+	}
+
+	return exist, nil
 }

--- a/src/core/tumblebug/types.go
+++ b/src/core/tumblebug/types.go
@@ -187,3 +187,49 @@ type VM struct {
 	} `json:"cspViewVmDetail"` // output
 
 }
+
+type NLBProtocolBase struct {
+	Protocol string // TCP|UDP
+	Port     string // 1-65535
+}
+
+type HealthCheckReq struct {
+	NLBProtocolBase
+	Interval  string // secs, Interval time between health checks.
+	Timeout   string // secs, Waiting time to decide an unhealthy VM when no response.
+	Threshold string // num, The number of continuous health checks to change the VM status.
+}
+
+type HealthCheckRes struct {
+	NLBProtocolBase
+	Interval  int // secs, Interval time between health checks.
+	Timeout   int // secs, Waiting time to decide an unhealthy VM when no response.
+	Threshold int // num, The number of continuous health checks to change the VM status.
+}
+
+type TargetGroup struct {
+	NLBProtocolBase
+	MCIS string
+	VMs  []string
+}
+
+// NLB
+type NLBBase struct {
+	Model
+	Config      string          `json:"connectionName"`
+	VPC         string          `json:"vNetId"`
+	Type        string          `json:"type" enums:"PUBLIC,INTERNAL"`
+	Scope       string          `json:"scope" enums:"REGION,GLOBAL"`
+	Listener    NLBProtocolBase `json:"listener"`
+	TargetGroup TargetGroup     `json:"targetGroup"`
+}
+
+type NLBRes struct {
+	NLBBase
+	HealthChecker HealthCheckRes `json:"healthChecker"`
+}
+
+type NLBReq struct {
+	NLBBase
+	HealthChecker HealthCheckReq `json:"healthChecker"`
+}

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -626,6 +626,11 @@ var doc = `{
                 "label": {
                     "type": "string"
                 },
+                "loadbalancer": {
+                    "type": "string",
+                    "default": "haproxy",
+                    "example": "haproxy"
+                },
                 "name": {
                     "type": "string",
                     "example": "cluster-01"
@@ -740,6 +745,11 @@ var doc = `{
                 },
                 "label": {
                     "type": "string"
+                },
+                "loadbalancer": {
+                    "type": "string",
+                    "default": "haproxy",
+                    "example": "haproxy"
                 },
                 "mcis": {
                     "type": "string"

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -611,6 +611,11 @@
                 "label": {
                     "type": "string"
                 },
+                "loadbalancer": {
+                    "type": "string",
+                    "default": "haproxy",
+                    "example": "haproxy"
+                },
                 "name": {
                     "type": "string",
                     "example": "cluster-01"
@@ -725,6 +730,11 @@
                 },
                 "label": {
                     "type": "string"
+                },
+                "loadbalancer": {
+                    "type": "string",
+                    "default": "haproxy",
+                    "example": "haproxy"
                 },
                 "mcis": {
                     "type": "string"

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -39,6 +39,10 @@ definitions:
         type: string
       label:
         type: string
+      loadbalancer:
+        default: haproxy
+        example: haproxy
+        type: string
       name:
         example: cluster-01
         type: string
@@ -116,6 +120,10 @@ definitions:
       kind:
         type: string
       label:
+        type: string
+      loadbalancer:
+        default: haproxy
+        example: haproxy
         type: string
       mcis:
         type: string

--- a/src/scripts/k8s-init.sh
+++ b/src/scripts/k8s-init.sh
@@ -6,7 +6,7 @@ cat << EOF > kubeadm-config.yaml
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
 imageRepository: k8s.gcr.io
-controlPlaneEndpoint: $4:9998
+controlPlaneEndpoint: $4:$5
 dns:
   type: CoreDNS
 apiServer:


### PR DESCRIPTION
- feat: Add support for loadbalancer NLB
  - nlb 방식 추가
  - cluster 생성시  parameter 추가
     ex) loadbalancer : nlb  (default: haproxy)
  - ibm, cloudit 은 미지원 (추후 지원 예정)
     - ibm : nlb 생성시 10분 이상 시간 소요됨, worker node join 이 안되는 현상 (확인 필요)
     - cloudit : 클러스터 삭제시 nlb 를 먼저 삭제 해야 함. 로직 변경 필요. 
  - aws, gcp, tencent, alibaba, openstack, azure 1차 지원

Tested with

CB-Spider (https://github.com/cloud-barista/cb-spider/releases/tag/v0.6.8)
CB-Tumblebug (https://github.com/cloud-barista/cb-tumblebug 최신소스) 
