### PR TITLE
feat:Add RootDiskType & RootDiskSize param to Create Cluster

### DIFF
--- a/docs/test/cluster-create.sh
+++ b/docs/test/cluster-create.sh
@@ -67,14 +67,18 @@ create() {
 				{
 					"connection": "config-azure-koreacentral",
 					"count": 3,
-					"spec": "Standard_B2s"
+					"spec": "Standard_B2s",
+					"rootDiskType": "defalut",
+					"rootDiskSize": "defalut"
 				}
 			],
 			"worker": [
 				{
 					"connection": "config-ibm-jp-tok",
 					"count": 1,
-					"spec": "bx2-2x8"
+					"spec": "bx2-2x8",
+					"rootDiskType": "defalut",
+					"rootDiskSize": "defalut"
 				}
 			]
 		}

--- a/docs/test/node-add.sh
+++ b/docs/test/node-add.sh
@@ -52,9 +52,11 @@ create() {
 		{
 			"worker": [
 				{
-					"connection": "config-ibm-jp-tok",
+					"connection": "config-aws-ap-northeast-1",
 					"count": 1,
-					"spec": "bx2-2x8"
+					"spec": "t2.medium",
+					"rootDiskType": "defalut",
+					"rootDiskSize": "defalut"
 				}
 			]
 		}

--- a/src/core/app/const.go
+++ b/src/core/app/const.go
@@ -71,9 +71,11 @@ type NodeReq struct {
 }
 
 type NodeSetReq struct {
-	Connection string `json:"connection" example:"config-aws-ap-northeast-2"`
-	Count      int    `json:"count" example:"3"`
-	Spec       string `json:"spec" example:"t2.medium"`
+	Connection   string `json:"connection" example:"config-aws-ap-northeast-2"`
+	Count        int    `json:"count" example:"3"`
+	Spec         string `json:"spec" example:"t2.medium"`
+	RootDiskType string `json:"rootDiskType" example:"default"`
+	RootDiskSize string `json:"rootDiskSize" example:"default"`
 }
 
 type ClusterConfigReq struct {

--- a/src/core/service/cluster.go
+++ b/src/core/service/cluster.go
@@ -158,7 +158,7 @@ func CreateCluster(namespace string, minorversion string, patchversion string, r
 				cluster.CpLeader = name
 			}
 			NLB.TargetGroup.VMs = append(NLB.TargetGroup.VMs, name)
-			mcis.VMs = append(mcis.VMs, mcir.NewVM(namespace, name, mcisName))
+			mcis.VMs = append(mcis.VMs, mcir.NewVM(namespace, name, mcisName, req.ControlPlane[0].RootDiskType, req.ControlPlane[0].RootDiskSize))
 			provisioner.AppendControlPlaneMachine(name, mcir.csp, mcir.region, mcir.zone, mcir.credential)
 		}
 	}
@@ -175,7 +175,7 @@ func CreateCluster(namespace string, minorversion string, patchversion string, r
 			// make mics reuqest & provisioner data
 			for i := 0; i < mcir.vmCount; i++ {
 				name := lang.GenerateNewNodeName(string(app.WORKER), idx+1)
-				mcis.VMs = append(mcis.VMs, mcir.NewVM(namespace, name, mcisName))
+				mcis.VMs = append(mcis.VMs, mcir.NewVM(namespace, name, mcisName, worker.RootDiskType, worker.RootDiskSize))
 				provisioner.AppendWorkerNodeMachine(name, mcir.csp, mcir.region, mcir.zone, mcir.credential)
 				idx = idx + 1
 			}

--- a/src/core/service/mcir.go
+++ b/src/core/service/mcir.go
@@ -185,7 +185,7 @@ func (self *MCIR) CreateIfNotExist() (model.ClusterReason, string) {
 }
 
 /* new a VM template */
-func (self *MCIR) NewVM(namespace string, name string, mcisName string) tumblebug.VM {
+func (self *MCIR) NewVM(namespace string, name string, mcisName string, diskType string, diskSize string) tumblebug.VM {
 	vm := tumblebug.NewVM(namespace, name, mcisName)
 	vm.Config = self.config
 	vm.VPC = self.vpcName
@@ -194,6 +194,8 @@ func (self *MCIR) NewVM(namespace string, name string, mcisName string) tumblebu
 	vm.SSHKey = self.sshkeyName
 	vm.Image = self.imageName
 	vm.Spec = self.specName
+	vm.RootDiskType = diskType
+	vm.RootDiskSize = diskSize
 	return *vm
 }
 

--- a/src/core/service/node.go
+++ b/src/core/service/node.go
@@ -107,7 +107,7 @@ func AddNode(namespace string, clusterName string, req *app.NodeReq) (*model.Nod
 		} else {
 			for i := 0; i < mcir.vmCount; i++ {
 				name := lang.GenerateNewNodeName(string(app.WORKER), idx)
-				vm := mcir.NewVM(namespace, name, mcisName)
+				vm := mcir.NewVM(namespace, name, mcisName, worker.RootDiskType, worker.RootDiskSize)
 				if err := vm.POST(); err != nil {
 					cleanUpNodes(*provisioner)
 					return nil, err

--- a/src/core/tumblebug/types.go
+++ b/src/core/tumblebug/types.go
@@ -174,10 +174,12 @@ type VM struct {
 	UserAccount   string   `json:"vmUserAccount"`
 	UserPassword  string   `json:"vmUserPassword"`
 	Description   string   `json:"description"`
-	PublicIP      string   `json:"publicIP"`      // output
-	PrivateIP     string   `json:"privateIP"`     // output
-	Status        VMStatus `json:"status"`        // output
-	SystemMessage string   `json:"systemMessage"` // output
+	PublicIP      string   `json:"publicIP"`                                 // output
+	PrivateIP     string   `json:"privateIP"`                                // output
+	Status        VMStatus `json:"status"`                                   // output
+	SystemMessage string   `json:"systemMessage"`                            // output
+	RootDiskType  string   `json:"rootDiskType,omitempty" example:"default"` // "", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure: ["PremiumSSD", "StandardSSD", "StandardHHD"], GCP: ["pd-standard", "pd-balanced", "pd-ssd", "pd-extreme"], ALIBABA: ["cloud_efficiency", "cloud", "cloud_ssd"], TENCENT: ["CLOUD_PREMIUM", "CLOUD_SSD"]
+	RootDiskSize  string   `json:"rootDiskSize,omitempty" example:"default"` // "default", Integer (GB): ["50", ..., "1000"]
 	Region        struct {
 		Region string `json:"region"`
 		Zone   string `json:"zone"`

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -695,6 +695,14 @@ var doc = `{
                     "type": "integer",
                     "example": 3
                 },
+                "rootDiskSize": {
+                    "type": "string",
+                    "example": "default"
+                },
+                "rootDiskType": {
+                    "type": "string",
+                    "example": "default"
+                },
                 "spec": {
                     "type": "string",
                     "example": "t2.medium"

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -680,6 +680,14 @@
                     "type": "integer",
                     "example": 3
                 },
+                "rootDiskSize": {
+                    "type": "string",
+                    "example": "default"
+                },
+                "rootDiskType": {
+                    "type": "string",
+                    "example": "default"
+                },
                 "spec": {
                     "type": "string",
                     "example": "t2.medium"

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -86,6 +86,12 @@ definitions:
       count:
         example: 3
         type: integer
+      rootDiskSize:
+        example: default
+        type: string
+      rootDiskType:
+        example: default
+        type: string
       spec:
         example: t2.medium
         type: string


### PR DESCRIPTION
- Add RootDiskType & RootDiskSize parameters 
  - 클러스터 생성시 controlplane, worker 단위로만 가능함
  - 기본 값인 default, default 로 값이 제대로 전달 되는 지 테스트 함

Tested with

CB-Spider (https://github.com/cloud-barista/cb-spider/releases/tag/v0.6.8)
CB-Tumblebug (https://github.com/cloud-barista/cb-tumblebug/tag/v0.6.2)
