### PR TITLE
fix: boostrap.sh output check

### DIFF
--- a/src/core/provision/machine.go
+++ b/src/core/provision/machine.go
@@ -140,10 +140,8 @@ func (self *Machine) bootstrap(networkCni app.NetworkCni, k8sVersion string) err
 	}
 
 	// 2. execute bootstrap.sh
-	if output, err := self.executeSSH(REMOTE_TARGET_PATH+"/bootstrap.sh %s %s %s %s %s", k8sVersion, self.CSP, self.Name, self.PublicIP, networkCni); err != nil {
+	if _, err := self.executeSSH(REMOTE_TARGET_PATH+"/bootstrap.sh %s %s %s %s %s", k8sVersion, self.CSP, self.Name, self.PublicIP, networkCni); err != nil {
 		return errors.New(fmt.Sprintf("Failed to execute bootstrap.sh (node=%s)", self.Name))
-	} else if !strings.Contains(output, "kubectl set on hold") {
-		return errors.New(fmt.Sprintf("Failed to execute bootstrap.sh shell. (node=%s, cause='kubectl not set on hold')", self.Name))
 	}
 
 	return nil


### PR DESCRIPTION
* bootstrap.sh 실행 결과  체크 시 런타임 환경에 따라 output에 포함 안될 수 있는 문자열 확인하고 오류로 처리하는 부분 제거
