### PR TITLE
fix: VM default account & ssh handshake logs

### DIFF
--- a/src/core/model/cluster.go
+++ b/src/core/model/cluster.go
@@ -83,7 +83,9 @@ func (self *Cluster) Select() (bool, error) {
 	key := getStoreClusterKey(self.Namespace, self.Name)
 	keyValue, err := app.CBStore.Get(key)
 	if err != nil {
-		return exists, err
+		if !strings.Contains(err.Error(), "bucket not") {
+			return exists, err
+		}
 	}
 	exists = (keyValue != nil)
 	if exists {

--- a/src/core/provision/machine.go
+++ b/src/core/provision/machine.go
@@ -29,7 +29,17 @@ func (self *Machine) executeSSH(format string, a ...interface{}) (string, error)
 			ServerPort: address,
 		}, command)
 	if err != nil {
-		logger.Warnf("[%s] Failed to run SSH command. (server=%s, cause='%v', command='%s', output='%s')", self.Name, address, err, command, output)
+		if strings.Contains(err.Error(), "handshake failed") {
+			if self.Username == "" {
+				logger.Warnf("[%s] Failed to run SSH command - username is empty (server=%s, key=%s, command='%s', cause='%v')", self.Name, address, len(self.Credential), command, err)
+			} else if self.Credential == "" {
+				logger.Warnf("[%s] Failed to run SSH command - private-key is empty (server=%s, command='%s', cause='%v')", self.Name, address, command, err)
+			} else {
+				logger.Warnf("[%s] Failed to run SSH command. (server=%s, command='%s', cause='%v')", self.Name, address, command, err)
+			}
+		} else {
+			logger.Warnf("[%s] Failed to run SSH command. (server=%s, username=%s, key=%s, command='%s', cause='%v')", self.Name, address, self.Username, len(self.Credential), command, err)
+		}
 	}
 	return output, err
 }

--- a/src/core/provision/provisioner.go
+++ b/src/core/provision/provisioner.go
@@ -107,7 +107,7 @@ func (self *Provisioner) BindVM(vms []tumblebug.VM) ([]*model.Node, error) {
 		if machine != nil {
 			machine.PublicIP = vm.PublicIP
 			machine.PrivateIP = vm.PrivateIP
-			machine.Username = vm.UserAccount
+			machine.Username = lang.NVL(vm.UserAccount, tumblebug.VM_USER_ACCOUNT)
 			machine.Region = lang.NVL(vm.Region.Region, machine.Region) // region, zone 공백인 경우가 간혹 있음
 			machine.Zone = lang.NVL(vm.Region.Zone, machine.Zone)
 			machine.Spec = vm.CspViewVmDetail.VMSpecName

--- a/src/scripts/bootstrap.sh
+++ b/src/scripts/bootstrap.sh
@@ -10,7 +10,7 @@ sudo hostnamectl set-hostname ${HOSTNAME}
 
 if [[ "${K8S_VERSION}" == "1.23"* ]]; then 
 
-sudo swapoff -a && sed -i '/swap/s/^/#/' /etc/fstab
+sudo swapoff -a && sudo sed -i '/swap/s/^/#/' /etc/fstab
 # br_netfilter
 sudo cat <<EOF | sudo tee /etc/modules-load.d/k8s.conf
 br_netfilter
@@ -84,7 +84,7 @@ sudo bash -c 'cat > /etc/docker/daemon.json <<EOF
 }
 EOF'
 
-sudo swapoff -a && sed -i '/swap/s/^/#/' /etc/fstab
+sudo swapoff -a && sudo sed -i '/swap/s/^/#/' /etc/fstab
 
 sudo mkdir -p /etc/systemd/system/docker.service.d
 sudo systemctl daemon-reload
@@ -120,7 +120,7 @@ if [ -f "/etc/kubernetes/kubelet.conf" ]; then
   kubectl --kubeconfig=/etc/kubernetes/kubelet.conf annotate node {{HOSTNAME}} kilo.squat.ai/force-endpoint=${PUBLIC_IP}:51820 --overwrite
 fi
 exit 0
-fi' | sed "s/{{HOSTNAME}}/${HOSTNAME}/g" | sed "s/{{PUBLIC_IP}}/${PUBLIC_IP}/g" | sudo tee /lib/systemd/system/mcks-bootstrap > /dev/null
+fi' | sudo sed "s/{{HOSTNAME}}/${HOSTNAME}/g" | sudo sed "s/{{PUBLIC_IP}}/${PUBLIC_IP}/g" | sudo tee /lib/systemd/system/mcks-bootstrap > /dev/null
 sudo chmod +x /lib/systemd/system/mcks-bootstrap
 fi
 
@@ -148,7 +148,7 @@ if [ -f "/etc/kubernetes/kubelet.conf" ]; then
   fi
 fi
 exit 0
-fi' | sed "s/{{HOSTNAME}}/${HOSTNAME}/g" | sed "s/{{PUBLIC_IP}}/${PUBLIC_IP}/g" | sudo tee /lib/systemd/system/mcks-bootstrap > /dev/null
+fi' | sudo sed "s/{{HOSTNAME}}/${HOSTNAME}/g" | sudo sed "s/{{PUBLIC_IP}}/${PUBLIC_IP}/g" | sudo tee /lib/systemd/system/mcks-bootstrap > /dev/null
 sudo chmod +x /lib/systemd/system/mcks-bootstrap
 fi
 


### PR DESCRIPTION
* MCIS에서 vm default 계정이 공백일 경우 default 계정 (cb-user) 지정
* SSH handshake logs 세분화
* boostrap.sh permission error log  hidden 처리
* datastore 가 비어있을 경우 bucket not 오류와 exist 오류 구분 처리

* Tested with
  * CB-Spider (https://github.com/cloud-barista/cb-spider/releases/tag/v0.6.8)
  * CB-Tumblebug (https://github.com/cloud-barista/cb-tumblebug/tag/v0.6.3)