### PR TITLE
feat:Add external etcd cluster

### DIFF
--- a/docs/design/entity.md
+++ b/docs/design/entity.md
@@ -22,7 +22,8 @@
     networkCni: "",
     label: "",
     installMonAgent: "",
-    loadbalancer: ""
+    loadbalancer: "",
+    etcd:"",
     k8sVersion: "",
     description: "",
     createdTime: "",
@@ -75,6 +76,7 @@
 |networkCni         |network CNI 정보             |string |                                     |
 |label              |label                       |string |                                     |
 |loadbalancer       |loadbalancer                |string |                                     |
+|etcd               |etcd                        |string |                                     |
 |installMonAgent    |모니터링 에이전트 설치 여부        |string | yes/no (no가 아니면 설치)              |
 |description        |description                 |string |                                     |
 |createdTime        |생성일자                      |string |                                     |
@@ -104,6 +106,8 @@
 * CreateVmSpecFailedReason : VM 타입 생성 실패
 * SetupBoostrapFailedReason : OS 기본 패키지 설치 실패
 * SetupHaproxyFailedReason : HAProxy 설치 실패
+* CreateNLBFailedReason : NLB 생성 실패
+* InitExternalEtcdFailedReason : External Etcd 설치 실패
 * InitControlPlaneFailedReason : ControlPlane Init. 실패
 * SetupNetworkCNIFailedReason : Network CNI 설치 실패
 * JoinControlPlaneFailedReason : ControlPlane join 실패

--- a/src/core/app/const.go
+++ b/src/core/app/const.go
@@ -5,6 +5,8 @@ type ROLE string
 type Kind string
 type NetworkCni string
 type StatusCode int
+type Loadbalancer string
+type Etcd string
 
 const (
 	CSP_AWS       CSP = "aws"
@@ -32,8 +34,11 @@ const (
 	NETWORKCNI_KILO  NetworkCni = "kilo"
 	NETWORKCNI_CANAL NetworkCni = "canal"
 
-	LB_HAPROXY = "haproxy"
-	LB_NLB     = "nlb"
+	LB_HAPROXY Loadbalancer = "haproxy"
+	LB_NLB     Loadbalancer = "nlb"
+
+	ETCD_LOCAL    Etcd = "local"
+	ETCD_EXTERNAL Etcd = "external"
 
 	POD_CIDR       = "10.244.0.0/16"
 	SERVICE_CIDR   = "10.96.0.0/12"
@@ -90,7 +95,8 @@ type ClusterConfigKubernetesReq struct {
 	StorageClass     struct {
 		Nfs ClusterStorageClassNfsReq `json:"nfs"`
 	} `json:"storageclass"`
-	Loadbalancer string `json:"loadbalancer" example:"haproxy"`
+	Loadbalancer Loadbalancer `json:"loadbalancer" example:"haproxy" enums:"haproxy,nlb"`
+	Etcd         Etcd         `json:"etcd" example:"local" enums:"local,external"`
 }
 
 type ClusterStorageClassNfsReq struct {

--- a/src/core/model/types.go
+++ b/src/core/model/types.go
@@ -30,6 +30,7 @@ const (
 	SetupBoostrapFailedReason                 = ClusterReason("SetupBoostrapFailedReason")
 	SetupHaproxyFailedReason                  = ClusterReason("SetupHaproxyFailedReason")
 	InitControlPlaneFailedReason              = ClusterReason("InitControlPlaneFailedReason")
+	InitExternalEtcdFailedReason              = ClusterReason("InitExternalEtcdFailedReason")
 	SetupNetworkCNIFailedReason               = ClusterReason("SetupNetworkCNIFailedReason")
 	SetupStorageClassFailedReason             = ClusterReason("SetupStorageClassFailedReason")
 	JoinControlPlaneFailedReason              = ClusterReason("JoinControlPlaneFailedReason")
@@ -46,20 +47,21 @@ type ListModel struct {
 
 type Cluster struct {
 	Model
-	Status          ClusterStatus  `json:"status"`
-	MCIS            string         `json:"mcis"`
-	Namespace       string         `json:"namespace"`
-	Version         string         `json:"k8sVersion"`
-	ClusterConfig   string         `json:"clusterConfig"`
-	CpLeader        string         `json:"cpLeader"`
-	CpGroup         string         `json:"cpGroup"`
-	NetworkCni      app.NetworkCni `json:"networkCni" enums:"canal,kilo"`
-	Label           string         `json:"label"`
-	InstallMonAgent string         `json:"installMonAgent" example:"no" default:"yes"`
-	Loadbalancer    string         `json:"loadbalancer" example:"haproxy" default:"haproxy"`
-	Description     string         `json:"description"`
-	CreatedTime     string         `json:"createdTime" example:"2022-01-02T12:00:00Z" default:""`
-	Nodes           []*Node        `json:"nodes"`
+	Status          ClusterStatus    `json:"status"`
+	MCIS            string           `json:"mcis"`
+	Namespace       string           `json:"namespace"`
+	Version         string           `json:"k8sVersion"`
+	ClusterConfig   string           `json:"clusterConfig"`
+	CpLeader        string           `json:"cpLeader"`
+	CpGroup         string           `json:"cpGroup"`
+	NetworkCni      app.NetworkCni   `json:"networkCni" enums:"canal,kilo"`
+	Label           string           `json:"label"`
+	InstallMonAgent string           `json:"installMonAgent" example:"no" default:"yes"`
+	Loadbalancer    app.Loadbalancer `json:"loadbalancer" enums:"haproxy,nlb" example:"haproxy" default:"haproxy"`
+	Etcd            app.Etcd         `json:"etcd" enums:"local,external" example:"local" default:"local"`
+	Description     string           `json:"description"`
+	CreatedTime     string           `json:"createdTime" example:"2022-01-02T12:00:00Z" default:""`
+	Nodes           []*Node          `json:"nodes"`
 }
 
 type ClusterStatus struct {

--- a/src/core/service/mcir.go
+++ b/src/core/service/mcir.go
@@ -22,7 +22,6 @@ type MCIR struct {
 	spec         string //prameter
 	vmCount      int    //prameter
 	credential   string
-	nlbName      string
 	subnetName   string
 	vpcName      string
 	firewallName string
@@ -43,7 +42,6 @@ func NewMCIR(namespace string, role app.ROLE, nodeSetReq app.NodeSetReq) *MCIR {
 		config:       nodeSetReq.Connection,
 		spec:         nodeSetReq.Spec,
 		vmCount:      nodeSetReq.Count,
-		nlbName:      fmt.Sprintf("%s-nlb", nodeSetReq.Connection),
 		vpcName:      fmt.Sprintf("%s-vpc", nodeSetReq.Connection),
 		firewallName: fmt.Sprintf("%s-sg", nodeSetReq.Connection),
 		sshkeyName:   fmt.Sprintf("%s-sshkey", nodeSetReq.Connection),

--- a/src/core/tumblebug/mcis.go
+++ b/src/core/tumblebug/mcis.go
@@ -36,12 +36,8 @@ func NewNLB(ns string, mcisName string, groupId string) *NLBReq {
 		},
 		HealthChecker: HealthCheckReq{
 			NLBProtocolBase: NLBProtocolBase{Protocol: "TCP", Port: "22"},
-			Interval:        "10", Threshold: "3",
+			Interval:        "default", Threshold: "default", Timeout: "default",
 		},
-	}
-
-	if !strings.Contains(nlb.NLBBase.Config, string(app.CSP_AWS)) && !strings.Contains(nlb.NLBBase.Config, string(app.CSP_AZURE)) {
-		nlb.HealthChecker.Timeout = "9"
 	}
 
 	if strings.Contains(nlb.NLBBase.Config, string(app.CSP_GCP)) {

--- a/src/core/tumblebug/types.go
+++ b/src/core/tumblebug/types.go
@@ -165,7 +165,7 @@ type VM struct {
 	Model
 	mcisName      string   //private
 	VmGroupId     string   `json:"vmGroupId"`
-	VmGroupSize   string   `json:"VmGroupSize"`
+	VmGroupSize   string   `json:"vmGroupSize"`
 	Config        string   `json:"connectionName"`
 	VPC           string   `json:"vNetId"`
 	Subnet        string   `json:"subnetId"`
@@ -193,28 +193,29 @@ type VM struct {
 }
 
 type NLBProtocolBase struct {
-	Protocol string // TCP|UDP
-	Port     string // 1-65535
+	Protocol string `json:"protocol"` // TCP|UDP
+	Port     string `json:"port"`     // 1-65535
+	Ip       string `json:"ip"`
 }
 
 type HealthCheckReq struct {
 	NLBProtocolBase
-	Interval  string // secs, Interval time between health checks.
-	Timeout   string // secs, Waiting time to decide an unhealthy VM when no response.
-	Threshold string // num, The number of continuous health checks to change the VM status.
+	Interval  string `json:"interval"`  // secs, Interval time between health checks.
+	Timeout   string `json:"timeout"`   // secs, Waiting time to decide an unhealthy VM when no response.
+	Threshold string `json:"threshold"` // num, The number of continuous health checks to change the VM status.
 }
 
 type HealthCheckRes struct {
 	NLBProtocolBase
-	Interval  int // secs, Interval time between health checks.
-	Timeout   int // secs, Waiting time to decide an unhealthy VM when no response.
-	Threshold int // num, The number of continuous health checks to change the VM status.
+	Interval  int `json:"interval"`  // secs, Interval time between health checks.
+	Timeout   int `json:"timeout"`   // secs, Waiting time to decide an unhealthy VM when no response.
+	Threshold int `json:"threshold"` // num, The number of continuous health checks to change the VM status.
 }
 
 type TargetGroup struct {
 	NLBProtocolBase
-	MCIS      string
-	VmGroupId string
+	MCIS      string `json:"mcis"`
+	VmGroupId string `json:"vmGroupId"`
 }
 
 // NLB

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -90,24 +90,30 @@ var doc = `{
                         "required": true
                     },
                     {
+                        "minimum": 1,
                         "type": "integer",
                         "description": "if Control-Plane, \u003e= 2",
                         "name": "cpu-min",
                         "in": "query"
                     },
                     {
+                        "maximum": 99999,
+                        "minimum": 1,
                         "type": "integer",
                         "description": " \u003c= 99999",
                         "name": "cpu-max",
                         "in": "query"
                     },
                     {
+                        "minimum": 1,
                         "type": "integer",
                         "description": " if Control-Plane, \u003e= 2",
                         "name": "memory-min",
                         "in": "query"
                     },
                     {
+                        "maximum": 99999,
+                        "minimum": 1,
                         "type": "integer",
                         "description": " \u003c= 99999",
                         "name": "memory-max",
@@ -549,9 +555,20 @@ var doc = `{
         "app.ClusterConfigKubernetesReq": {
             "type": "object",
             "properties": {
+                "etcd": {
+                    "type": "string",
+                    "enum": [
+                        "local",
+                        "external"
+                    ],
+                    "example": "local"
+                },
                 "loadbalancer": {
                     "type": "string",
-                    "default": "haproxy",
+                    "enum": [
+                        "haproxy",
+                        "nlb"
+                    ],
                     "example": "haproxy"
                 },
                 "networkCni": {
@@ -578,7 +595,6 @@ var doc = `{
                     "type": "object",
                     "properties": {
                         "nfs": {
-                            "type": "object",
                             "$ref": "#/definitions/app.ClusterStorageClassNfsReq"
                         }
                     }
@@ -594,11 +610,9 @@ var doc = `{
             "properties": {
                 "installMonAgent": {
                     "type": "string",
-                    "default": "yes",
                     "example": "no"
                 },
                 "kubernetes": {
-                    "type": "object",
                     "$ref": "#/definitions/app.ClusterConfigKubernetesReq"
                 }
             }
@@ -607,7 +621,6 @@ var doc = `{
             "type": "object",
             "properties": {
                 "config": {
-                    "type": "object",
                     "$ref": "#/definitions/app.ClusterConfigReq"
                 },
                 "controlPlane": {
@@ -728,6 +741,15 @@ var doc = `{
                 "description": {
                     "type": "string"
                 },
+                "etcd": {
+                    "type": "string",
+                    "default": "local",
+                    "enum": [
+                        "local",
+                        "external"
+                    ],
+                    "example": "local"
+                },
                 "installMonAgent": {
                     "type": "string",
                     "default": "yes",
@@ -745,6 +767,10 @@ var doc = `{
                 "loadbalancer": {
                     "type": "string",
                     "default": "haproxy",
+                    "enum": [
+                        "haproxy",
+                        "nlb"
+                    ],
                     "example": "haproxy"
                 },
                 "mcis": {
@@ -770,7 +796,6 @@ var doc = `{
                     }
                 },
                 "status": {
-                    "type": "object",
                     "$ref": "#/definitions/model.ClusterStatus"
                 }
             }

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -75,24 +75,30 @@
                         "required": true
                     },
                     {
+                        "minimum": 1,
                         "type": "integer",
                         "description": "if Control-Plane, \u003e= 2",
                         "name": "cpu-min",
                         "in": "query"
                     },
                     {
+                        "maximum": 99999,
+                        "minimum": 1,
                         "type": "integer",
                         "description": " \u003c= 99999",
                         "name": "cpu-max",
                         "in": "query"
                     },
                     {
+                        "minimum": 1,
                         "type": "integer",
                         "description": " if Control-Plane, \u003e= 2",
                         "name": "memory-min",
                         "in": "query"
                     },
                     {
+                        "maximum": 99999,
+                        "minimum": 1,
                         "type": "integer",
                         "description": " \u003c= 99999",
                         "name": "memory-max",
@@ -534,9 +540,20 @@
         "app.ClusterConfigKubernetesReq": {
             "type": "object",
             "properties": {
+                "etcd": {
+                    "type": "string",
+                    "enum": [
+                        "local",
+                        "external"
+                    ],
+                    "example": "local"
+                },
                 "loadbalancer": {
                     "type": "string",
-                    "default": "haproxy",
+                    "enum": [
+                        "haproxy",
+                        "nlb"
+                    ],
                     "example": "haproxy"
                 },
                 "networkCni": {
@@ -563,7 +580,6 @@
                     "type": "object",
                     "properties": {
                         "nfs": {
-                            "type": "object",
                             "$ref": "#/definitions/app.ClusterStorageClassNfsReq"
                         }
                     }
@@ -579,11 +595,9 @@
             "properties": {
                 "installMonAgent": {
                     "type": "string",
-                    "default": "yes",
                     "example": "no"
                 },
                 "kubernetes": {
-                    "type": "object",
                     "$ref": "#/definitions/app.ClusterConfigKubernetesReq"
                 }
             }
@@ -592,7 +606,6 @@
             "type": "object",
             "properties": {
                 "config": {
-                    "type": "object",
                     "$ref": "#/definitions/app.ClusterConfigReq"
                 },
                 "controlPlane": {
@@ -713,6 +726,15 @@
                 "description": {
                     "type": "string"
                 },
+                "etcd": {
+                    "type": "string",
+                    "default": "local",
+                    "enum": [
+                        "local",
+                        "external"
+                    ],
+                    "example": "local"
+                },
                 "installMonAgent": {
                     "type": "string",
                     "default": "yes",
@@ -730,6 +752,10 @@
                 "loadbalancer": {
                     "type": "string",
                     "default": "haproxy",
+                    "enum": [
+                        "haproxy",
+                        "nlb"
+                    ],
                     "example": "haproxy"
                 },
                 "mcis": {
@@ -755,7 +781,6 @@
                     }
                 },
                 "status": {
-                    "type": "object",
                     "$ref": "#/definitions/model.ClusterStatus"
                 }
             }

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -2,8 +2,16 @@ basePath: /mcks
 definitions:
   app.ClusterConfigKubernetesReq:
     properties:
+      etcd:
+        enum:
+        - local
+        - external
+        example: local
+        type: string
       loadbalancer:
-        default: haproxy
+        enum:
+        - haproxy
+        - nlb
         example: haproxy
         type: string
       networkCni:
@@ -25,7 +33,6 @@ definitions:
         properties:
           nfs:
             $ref: '#/definitions/app.ClusterStorageClassNfsReq'
-            type: object
         type: object
       version:
         example: 1.23.13
@@ -34,18 +41,15 @@ definitions:
   app.ClusterConfigReq:
     properties:
       installMonAgent:
-        default: "yes"
         example: "no"
         type: string
       kubernetes:
         $ref: '#/definitions/app.ClusterConfigKubernetesReq'
-        type: object
     type: object
   app.ClusterReq:
     properties:
       config:
         $ref: '#/definitions/app.ClusterConfigReq'
-        type: object
       controlPlane:
         items:
           $ref: '#/definitions/app.NodeSetReq'
@@ -126,6 +130,13 @@ definitions:
         type: string
       description:
         type: string
+      etcd:
+        default: local
+        enum:
+        - local
+        - external
+        example: local
+        type: string
       installMonAgent:
         default: "yes"
         example: "no"
@@ -138,6 +149,9 @@ definitions:
         type: string
       loadbalancer:
         default: haproxy
+        enum:
+        - haproxy
+        - nlb
         example: haproxy
         type: string
       mcis:
@@ -157,7 +171,6 @@ definitions:
         type: array
       status:
         $ref: '#/definitions/model.ClusterStatus'
-        type: object
     type: object
   model.ClusterList:
     properties:
@@ -309,18 +322,24 @@ paths:
         type: string
       - description: if Control-Plane, >= 2
         in: query
+        minimum: 1
         name: cpu-min
         type: integer
       - description: ' <= 99999'
         in: query
+        maximum: 99999
+        minimum: 1
         name: cpu-max
         type: integer
       - description: ' if Control-Plane, >= 2'
         in: query
+        minimum: 1
         name: memory-min
         type: integer
       - description: ' <= 99999'
         in: query
+        maximum: 99999
+        minimum: 1
         name: memory-max
         type: integer
       produces:

--- a/src/rest-api/router/cluster.go
+++ b/src/rest-api/router/cluster.go
@@ -135,7 +135,12 @@ func validateCreateClusterReq(clusterReq *app.ClusterReq) error {
 	clusterReq.Config.Kubernetes.PodCidr = lang.NVL(clusterReq.Config.Kubernetes.PodCidr, app.POD_CIDR)
 	clusterReq.Config.Kubernetes.ServiceCidr = lang.NVL(clusterReq.Config.Kubernetes.ServiceCidr, app.SERVICE_CIDR)
 	clusterReq.Config.Kubernetes.ServiceDnsDomain = lang.NVL(clusterReq.Config.Kubernetes.ServiceDnsDomain, app.SERVICE_DOMAIN)
-	clusterReq.Config.Kubernetes.Loadbalancer = lang.NVL(clusterReq.Config.Kubernetes.Loadbalancer, app.LB_HAPROXY)
+	if len(clusterReq.Config.Kubernetes.Loadbalancer) == 0 {
+		clusterReq.Config.Kubernetes.Loadbalancer = app.LB_HAPROXY
+	}
+	if len(clusterReq.Config.Kubernetes.Loadbalancer) == 0 {
+		clusterReq.Config.Kubernetes.Etcd = app.ETCD_LOCAL
+	}
 	if len(clusterReq.Config.Kubernetes.NetworkCni) == 0 {
 		clusterReq.Config.Kubernetes.NetworkCni = app.NETWORKCNI_KILO
 	}
@@ -155,6 +160,9 @@ func validateCreateClusterReq(clusterReq *app.ClusterReq) error {
 	}
 	if len(clusterReq.Config.Kubernetes.Loadbalancer) != 0 && !(clusterReq.Config.Kubernetes.Loadbalancer == app.LB_HAPROXY || clusterReq.Config.Kubernetes.Loadbalancer == app.LB_NLB) {
 		return errors.New("loadbalancer allows only haproxy or nlb")
+	}
+	if clusterReq.Config.Kubernetes.Etcd == app.ETCD_EXTERNAL && (clusterReq.ControlPlane[0].Count != 3 && clusterReq.ControlPlane[0].Count != 5 && clusterReq.ControlPlane[0].Count != 7) {
+		return errors.New("External etcd must have 3,5,7 controlPlane count")
 	}
 	if len(clusterReq.Name) == 0 {
 		return errors.New("Cluster name is empty")

--- a/src/scripts/bootstrap.sh
+++ b/src/scripts/bootstrap.sh
@@ -70,7 +70,7 @@ sudo apt-get install -y apt-transport-https ca-certificates curl software-proper
 sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 sudo apt-get update
-sudo apt-get install -y containerd.io=1.2.13-2 docker-ce=5:19.03.11~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:19.03.11~3-0~ubuntu-$(lsb_release -cs)
+sudo apt-get install -y docker-ce=5:19.03.11~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:19.03.11~3-0~ubuntu-$(lsb_release -cs)
 
 
 sudo bash -c 'cat > /etc/docker/daemon.json <<EOF

--- a/src/scripts/etcd-ca.sh
+++ b/src/scripts/etcd-ca.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+IPS=""
+for i in $@; do
+IPS+="\""$i"\", "
+done
+
+sudo wget -q \
+    https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/linux/cfssl \
+    https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/linux/cfssljson
+sudo chmod +x cfssl cfssljson
+sudo mv cfssl cfssljson /usr/local/bin/
+sudo mkdir -p /tmp/ca
+
+sudo cat <<EOF | sudo tee ca-config.json
+{
+    "signing": {
+        "default": {
+            "expiry": "8760h"
+        },
+        "profiles": {
+            "etcd": {
+                "expiry": "8760h",
+                "usages": ["signing","key encipherment","server auth","client auth"]
+            }
+        }
+    }
+}
+EOF
+
+sudo cat <<EOF | sudo tee ca-csr.json
+{
+  "CN": "etcd cluster",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "KR",
+      "L": "SEOUL",
+      "O": "Kubernetes",
+      "OU": "ETCD-CA",
+      "ST": "Cambridge"
+    }
+  ]
+}
+EOF
+
+sudo cfssl gencert -initca ca-csr.json | sudo cfssljson -bare ca
+
+sudo cat <<EOF | sudo tee etcd-csr.json
+{
+  "CN": "etcd",
+  "hosts": [
+    "localhost",
+    "127.0.0.1",
+    $IPS
+    "kubernetes",
+    "kubernetes.default",
+    "kubernetes.default.svc",
+    "kubernetes.default.svc.cluster",
+    "kubernetes.default.svc.cluster.local"
+  ],
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "KR",
+      "L": "SEOUL",
+      "O": "Kubernetes",
+      "OU": "etcd",
+      "ST": "Cambridge"
+    }
+  ]
+}
+EOF
+
+sudo cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=etcd etcd-csr.json | sudo cfssljson -bare etcd
+sudo chmod 644 etcd-key.pem
+sudo mv $HOME/ca.pem $HOME/etcd.pem $HOME/etcd-key.pem /tmp/ca
+sudo rm -rf *.json *.csr *.pem

--- a/src/scripts/etcd-conf.sh
+++ b/src/scripts/etcd-conf.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+ETCD_VER="v3.5.1"
+ETCD_NAME=$(hostname -s)
+NODE_IP=$(hostname -I)
+NODE_IPS=(${NODE_IP})
+regexp='([0-9]{1,3}\.){3}[0-9]{1,3}'
+CLUSTER=""
+
+for i in $@; do
+if [[ "$i" =~ $regexp ]]; then
+CLUSTER+=$i":2380,"
+else
+CLUSTER+=$i"=https://"
+fi
+done
+
+sudo mkdir -p /etc/kubernetes/pki/etcd
+sudo chown root.root $HOME/*.pem
+sudo mv $HOME/ca.pem $HOME/etcd.pem $HOME/etcd-key.pem /etc/kubernetes/pki/etcd
+
+sudo wget -q "https://github.com/etcd-io/etcd/releases/download/${ETCD_VER}/etcd-${ETCD_VER}-linux-amd64.tar.gz"
+sudo tar zxf etcd-${ETCD_VER}-linux-amd64.tar.gz
+sudo mv etcd-${ETCD_VER}-linux-amd64/etcd* /usr/local/bin/
+sudo rm -rf etcd*
+
+sudo cat <<EOF | sudo tee /etc/systemd/system/etcd.service
+[Unit]
+Description=etcd
+
+[Service]
+Type=exec
+ExecStart=/usr/local/bin/etcd \\
+  --name ${ETCD_NAME} \\
+  --cert-file=/etc/kubernetes/pki/etcd/etcd.pem \\
+  --key-file=/etc/kubernetes/pki/etcd/etcd-key.pem \\
+  --peer-cert-file=/etc/kubernetes/pki/etcd/etcd.pem \\
+  --peer-key-file=/etc/kubernetes/pki/etcd/etcd-key.pem \\
+  --trusted-ca-file=/etc/kubernetes/pki/etcd/ca.pem \\
+  --peer-trusted-ca-file=/etc/kubernetes/pki/etcd/ca.pem \\
+  --peer-client-cert-auth \\
+  --client-cert-auth \\
+  --initial-advertise-peer-urls https://${NODE_IPS[0]}:2380 \\
+  --listen-peer-urls https://0.0.0.0:2380 \\
+  --advertise-client-urls https://${NODE_IPS[0]}:2379 \\
+  --listen-client-urls https://0.0.0.0:2379 \\
+  --initial-cluster-token etcd-cluster-1 \\
+  --initial-cluster ${CLUSTER%\,} \\
+  --initial-cluster-state new
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now etcd

--- a/src/scripts/k8s-init-etcd.sh
+++ b/src/scripts/k8s-init-etcd.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# kubeadm-config 정의
+# - controlPlaneEndpoint 에 LB 지정 (9998 포트)
+# - advertise-address 에 Public IP 지정
+ALL="$@"
+LIST=($ALL)
+ETCDLIST=""
+for ((i=5; i<${#LIST[@]}; i++)); do
+if [ $i -eq 5 ]; then
+ETCDLIST+="- https://${LIST[$i]}:2379"
+elif [ $i -lt ${#LIST[@]} ]; then
+ETCDLIST+=$'\n'"      - https://${LIST[$i]}:2379"
+fi
+done
+
+cat << EOF > kubeadm-config.yaml
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
+imageRepository: k8s.gcr.io
+controlPlaneEndpoint: $4:$5
+dns:
+  type: CoreDNS
+apiServer:
+  extraArgs:
+    advertise-address: $4
+    authorization-mode: Node,RBAC
+etcd:
+  external:
+    endpoints:
+      $ETCDLIST
+    caFile: /etc/kubernetes/pki/etcd/ca.pem
+    certFile: /etc/kubernetes/pki/etcd/etcd.pem
+    keyFile: /etc/kubernetes/pki/etcd/etcd-key.pem
+networking:
+  dnsDomain: $3
+  podSubnet: $1
+  serviceSubnet: $2
+controllerManager: {}
+scheduler: {}
+EOF
+
+# Control-plane init
+sudo kubeadm init --v=5 --upload-certs --config kubeadm-config.yaml
+
+# control-plane leader 의 경우
+# - mcks-bootstrap 데몬이 자동 실행
+#systemctl status mcks-bootstrap


### PR DESCRIPTION
- Add external etcd cluster
  - external etcd 구성 시 control-plane 은 3,5,7 개로 제약함.
  - 설치 후 control-plane 리더 접속 후 아래와 같이 etcd cluster 확인 가능
    - $export ETCDCTL_API=3 
    - $export ETCDCTL_ENDPOINTS=https://192.168.36.5:2379,https://192.168.36.6:2379,https://192.168.36.7:2379
    - $export ETCDCTL_CACERT=/etc/kubernetes/pki/etcd/ca.pem
    - $export ETCDCTL_CERT=/etc/kubernetes/pki/etcd/etcd.pem 
    - $export ETCDCTL_KEY=/etc/kubernetes/pki/etcd/etcd-key.pem
    - $etcdctl member list -w table
    - $etcdctl endpoint status -w table
    - $etcdctl endpoint health -w table

Tested with

CB-Spider (https://github.com/cloud-barista/cb-spider/releases/tag/v0.6.8)
CB-Tumblebug (https://github.com/cloud-barista/cb-tumblebug/tag/v0.6.3)