### PR TITLE
feat : Support to ncpvcp nlb

### DIFF
--- a/src/core/service/cluster.go
+++ b/src/core/service/cluster.go
@@ -61,8 +61,13 @@ func CreateCluster(namespace string, req *app.ClusterReq) (*model.Cluster, error
 		connection := tumblebug.NewConnection(req.ControlPlane[0].Connection)
 		exists, _ := connection.GET()
 		if exists {
-			if strings.ToLower(connection.ProviderName) == string(app.CSP_IBM) || strings.ToLower(connection.ProviderName) == string(app.CSP_NCP) || strings.ToLower(connection.ProviderName) == string(app.CSP_NCPVPC) {
+			if strings.ToLower(connection.ProviderName) == string(app.CSP_IBM) || strings.ToLower(connection.ProviderName) == string(app.CSP_NCP) {
 				return nil, errors.New(fmt.Sprintf("%s does not yet supported nlb loadbalancer.", strings.ToLower(connection.ProviderName)))
+			}
+			if strings.ToLower(connection.ProviderName) == string(app.CSP_NCPVPC) {
+				if !strings.Contains(connection.RegionName, "sgn") && !strings.Contains(connection.RegionName, "jpn") {
+					return nil, errors.New(fmt.Sprintf("To use nlb in %s, must use SGN, JPN region", strings.ToLower(connection.ProviderName)))
+				}
 			}
 		}
 	}

--- a/src/core/service/mcir.go
+++ b/src/core/service/mcir.go
@@ -96,7 +96,13 @@ func (self *MCIR) CreateIfNotExist() (model.ClusterReason, string) {
 	}
 
 	// Create a VPC
-	vpc := tumblebug.NewVPC(self.namespace, self.vpcName, self.config, getCSPCidrBlock(self.csp))
+	cidr := getCSPCidrBlock(self.csp)
+	cidrSubnet := cidr
+	if self.csp == app.CSP_NCPVPC {
+		cidrSubnet = fmt.Sprintf("%s28", cidr[:len(cidr)-2])
+
+	}
+	vpc := tumblebug.NewVPC(self.namespace, self.vpcName, self.config, cidr, cidrSubnet)
 	exists, err := vpc.GET()
 	if err != nil {
 		return model.CreateVpcFailedReason, fmt.Sprintf("Failed to create a VPC. (cause='%v')", err)

--- a/src/core/tumblebug/mcir.go
+++ b/src/core/tumblebug/mcir.go
@@ -9,7 +9,7 @@ import (
 )
 
 /* new instance of VPC */
-func NewVPC(ns string, name string, conf string, cidrBlock string) *VPC {
+func NewVPC(ns string, name string, conf string, cidrBlock string, cidrSubnet string) *VPC {
 
 	return &VPC{
 		Model:     Model{Name: name, Namespace: ns},
@@ -18,7 +18,7 @@ func NewVPC(ns string, name string, conf string, cidrBlock string) *VPC {
 		Subnets: []Subnet{
 			{
 				Name:      fmt.Sprintf("%s-subnet", conf),
-				CidrBlock: cidrBlock},
+				CidrBlock: cidrSubnet},
 		},
 	}
 }


### PR DESCRIPTION
- NCPVPC 사용시 loadbalancer type nlb 지원 추가
  - mcks에서 nlb 사용을 위해서는 SGN(싱가포르), JPN(일본) 리전 사용해야함. 


Tested with

CB-Spider (https://github.com/cloud-barista/cb-spider) v0.7.0
CB-Tumblebug (https://github.com/cloud-barista/cb-tumblebug) v0.7.0